### PR TITLE
fix : Green Dinos Now Dynamically Update Speed Based on LevelManager

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/components/GreenDinoComponent.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/components/GreenDinoComponent.java
@@ -21,6 +21,8 @@ public class GreenDinoComponent extends Component implements Dinosaur {
     private final LocalTimer timer = FXGL.newLocalTimer();
     private boolean isPaused = false;
     private boolean isMuted = false;
+    private LevelManager levelManager;
+    private int lastLevel = -1;
 
     public void setPaused(boolean paused) {
         isPaused = paused;
@@ -30,11 +32,20 @@ public class GreenDinoComponent extends Component implements Dinosaur {
         isMuted = muted;
     }
 
+    public void setLevelManager(LevelManager levelManager) {
+        this.levelManager = levelManager;
+        this.verticalSpeed = levelManager.getEnemySpeed();
+        this.lastLevel = levelManager.getCurrentLevel();
+    }
+
     @Override
     public void onAdded(){
-        //Get the current enemy speed from the level manager
-        LevelManager levelManager = FXGL.geto("levelManager");
+        // Get the current enemy speed from the level manager if not already set
+        if (levelManager == null) {
+            levelManager = FXGL.geto("levelManager");
+        }
         verticalSpeed = levelManager.getEnemySpeed();
+        lastLevel = levelManager.getCurrentLevel();
     }
     /**
      * Summary :
@@ -45,7 +56,11 @@ public class GreenDinoComponent extends Component implements Dinosaur {
     @Override
     public void onUpdate(double ptf) {
         if(isPaused) return;
-
+        // Update speed if level has changed
+        if (levelManager != null && levelManager.getCurrentLevel() != lastLevel) {
+            verticalSpeed = levelManager.getEnemySpeed();
+            lastLevel = levelManager.getCurrentLevel();
+        }
         entity.translateY(verticalSpeed);
 
         //The dinosaur shoots every 2 seconds

--- a/src/main/java/com/dinosaur/dinosaurexploder/controller/DinosaurController.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/controller/DinosaurController.java
@@ -246,16 +246,19 @@ public class DinosaurController {
             }
             projectile.removeFromWorld();
             greenDino.removeFromWorld();
-            score.getComponent(ScoreComponent.class).incrementScore(1);
+
+            score.getComponent(ScoreComponent.class).incrementScore(levelManager.getCurrentLevel());
             levelManager.incrementDefeatedEnemies();
-            if(levelManager.shouldAdvanceLevel()){
+            
+            if (levelManager.shouldAdvanceLevel()) {
                 levelManager.nextLevel();
-                // Update all green dinos with new levelManager values
+                // Update all green dinos with new LevelManager values
                 FXGL.getGameWorld().getEntitiesByType(EntityType.GREEN_DINO).forEach(e -> {
                     if(e.hasComponent(GreenDinoComponent.class)) {
                         e.getComponent(GreenDinoComponent.class).setLevelManager(levelManager);
                     }
                 });
+
                 showLevelMessage();
                 System.out.println("Level up!");
             }

--- a/src/main/java/com/dinosaur/dinosaurexploder/controller/DinosaurController.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/controller/DinosaurController.java
@@ -250,6 +250,12 @@ public class DinosaurController {
             levelManager.incrementDefeatedEnemies();
             if(levelManager.shouldAdvanceLevel()){
                 levelManager.nextLevel();
+                // Update all green dinos with new levelManager values
+                FXGL.getGameWorld().getEntitiesByType(EntityType.GREEN_DINO).forEach(e -> {
+                    if(e.hasComponent(GreenDinoComponent.class)) {
+                        e.getComponent(GreenDinoComponent.class).setLevelManager(levelManager);
+                    }
+                });
                 showLevelMessage();
                 System.out.println("Level up!");
             }
@@ -283,6 +289,12 @@ public class DinosaurController {
 
                 score.getComponent(ScoreComponent.class).incrementScore(levelManager.getCurrentLevel());
                 levelManager.nextLevel();
+                // Update all green dinos with new levelManager values
+                FXGL.getGameWorld().getEntitiesByType(EntityType.GREEN_DINO).forEach(e -> {
+                    if(e.hasComponent(GreenDinoComponent.class)) {
+                        e.getComponent(GreenDinoComponent.class).setLevelManager(levelManager);
+                    }
+                });
                 showLevelMessage();
                 System.out.println("Level up!");
             } else{

--- a/src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java
@@ -130,13 +130,17 @@ public class GameEntityFactory implements EntityFactory {
          */
         @Spawns("greenDino")
         public Entity newGreenDino(SpawnData data) {
-                return entityBuilderBase(data, EntityType.GREEN_DINO)
+                Entity greenDino = entityBuilderBase(data, EntityType.GREEN_DINO)
                                 .with(new OffscreenCleanComponent())
                                 .view(texture(GameConstants.GREEN_DINO_IMAGE_FILE, 80, 60))
                                 .bbox(new HitBox(BoundingShape.box(65, 55)))
                                 .collidable()
                                 .with(new GreenDinoComponent())
                                 .build();
+                // Set LevelManager reference
+                GreenDinoComponent comp = greenDino.getComponent(GreenDinoComponent.class);
+                comp.setLevelManager(FXGL.geto("levelManager"));
+                return greenDino;
         }
 
         /**


### PR DESCRIPTION
### ✅ PR Checklist

<!-- ✅ To check a box, write: `[x]` (no space between the brackets) -->

- [x] My PR title follows the format: `[Type]: clear description of change`
- [x] I used the correct `type`: Feature, Fix, Refactor, Docs, Test, Chore
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).


### 📝 What does this PR do?

->Adds a LevelManager reference to green dinosaurs so they can dynamically update speed based on the current level.
->Ensures green dinos move and shoot faster as levels increase, reflecting the latest level stats.
->Aligns green dino behavior with the robust pattern already used for red dinos, but in a more flexible and future-proof way.

### 🔗 Related Issue
This PR fixes/closes: #192

- [x] This PR fixes/closes: #192
- [ ] This PR doesn’t address a specific issue.


