### PR TITLE
[Bug/Feature] : AudioManager integration on game screens

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 import com.dinosaur.dinosaurexploder.utils.AudioManager;
 
 public class DinosaurMenu extends FXGLMenu {
-    private final MediaPlayer mainMenuSound;
+    //private final MediaPlayer mainMenuSound;
     LanguageManager languageManager = LanguageManager.getInstance();
     private final Button startButton = new Button("Start Game");
     private final Button quitButton = new Button("Quit");
@@ -50,9 +50,11 @@ public class DinosaurMenu extends FXGLMenu {
     public DinosaurMenu() {
         super(MenuType.MAIN_MENU);
         
-        mainMenuSound = new MediaPlayer(
-            new Media(Objects.requireNonNull(getClass().getResource("/assets/sounds/mainMenu.wav")).toExternalForm())
-        );
+//        mainMenuSound = new MediaPlayer(
+//            new Media(Objects.requireNonNull(getClass().getResource("/assets/sounds/mainMenu.wav")).toExternalForm())
+//        );
+        AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
+        System.out.println("Volume ship selection: "+AudioManager.getInstance().getVolume());
 
         // Listen for language changes and update menu text
         languageManager.selectedLanguageProperty().addListener((observable, oldValue, newValue) -> updateTexts());
@@ -60,6 +62,7 @@ public class DinosaurMenu extends FXGLMenu {
         // Load the main menu sound
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
         AudioManager.getInstance().stopMusic();
+        System.out.println("Volume main menu: "+AudioManager.getInstance().getVolume());
 
         
 
@@ -112,10 +115,11 @@ public class DinosaurMenu extends FXGLMenu {
         Label volumeLabel = new Label(String.format("%.0f%%", settings.getVolume() * 100));
         volumeSlider.valueProperty().addListener((observable, oldValue, newValue) -> {
         AudioManager.getInstance().setVolume(newValue.doubleValue()); // <--- THIS LINE IS IMPORTANT
-        mainMenuSound.setVolume(newValue.doubleValue());
-        settings.setVolume(newValue.doubleValue());
-        SettingsProvider.saveSettings(settings);
-        volumeLabel.setText(String.format("%.0f%%", newValue.doubleValue() * 100));
+        //mainMenuSound.setVolume(newValue.doubleValue());
+            AudioManager.getInstance().setVolume(newValue.doubleValue());
+            settings.setVolume(newValue.doubleValue());
+            SettingsProvider.saveSettings(settings);
+            volumeLabel.setText(String.format("%.0f%%", newValue.doubleValue() * 100));
         });
 
         try {
@@ -209,13 +213,13 @@ public class DinosaurMenu extends FXGLMenu {
 
             startButton.setOnAction(event -> {
                 FXGL.getSceneService().pushSubScene(new ShipSelectionMenu());
-                mainMenuSound.stop();
+                //mainMenuSound.stop();
             });
 
             imageViewPlaying.setOnMouseClicked(mouseEvent -> {
                 boolean newMutedState = !AudioManager.getInstance().isMuted();
                 AudioManager.getInstance().setMuted(newMutedState); // <--- THIS LINE IS IMPORTANT
-                mainMenuSound.setMute(newMutedState);
+                //mainMenuSound.setMute(newMutedState);
                 settings.setMuted(newMutedState);
                 imageViewPlaying.setImage(newMutedState ? mute : audioOn);
                 SettingsProvider.saveSettings(settings);
@@ -264,8 +268,9 @@ public class DinosaurMenu extends FXGLMenu {
     public void onEnteredFrom(Scene prevState) {
         super.onEnteredFrom(prevState);
         FXGL.getAudioPlayer().stopAllSounds();
-        mainMenuSound.play();
-        mainMenuSound.setMute(AudioManager.getInstance().isMuted()); // Optional: sync menu music with global mute
-        mainMenuSound.setVolume(AudioManager.getInstance().getVolume()); // Optional: sync menu music with global volume
+        AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
+        //mainMenuSound.play();
+        //mainMenuSound.setMute(AudioManager.getInstance().isMuted()); // Optional: sync menu music with global mute
+        //mainMenuSound.setVolume(AudioManager.getInstance().getVolume()); // Optional: sync menu music with global volume
         }
 }

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -265,12 +265,9 @@ public class DinosaurMenu extends FXGLMenu {
     }
 
     @Override
-    public void onEnteredFrom(Scene prevState) {
+    public void onEnteredFrom(@NotNull Scene prevState) {
         super.onEnteredFrom(prevState);
         FXGL.getAudioPlayer().stopAllSounds();
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
-        //mainMenuSound.play();
-        //mainMenuSound.setMute(AudioManager.getInstance().isMuted()); // Optional: sync menu music with global mute
-        //mainMenuSound.setVolume(AudioManager.getInstance().getVolume()); // Optional: sync menu music with global volume
         }
 }

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -52,7 +52,6 @@ public class DinosaurMenu extends FXGLMenu {
 
         AudioManager.getInstance().setVolume(settings.getVolume());
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
-        System.out.println("Volume ship selection: "+AudioManager.getInstance().getVolume());
 
         // Listen for language changes and update menu text
         languageManager.selectedLanguageProperty().addListener((observable, oldValue, newValue) -> updateTexts());

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -49,10 +49,8 @@ public class DinosaurMenu extends FXGLMenu {
 
     public DinosaurMenu() {
         super(MenuType.MAIN_MENU);
-        
-//        mainMenuSound = new MediaPlayer(
-//            new Media(Objects.requireNonNull(getClass().getResource("/assets/sounds/mainMenu.wav")).toExternalForm())
-//        );
+
+        AudioManager.getInstance().setVolume(settings.getVolume());
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
         System.out.println("Volume ship selection: "+AudioManager.getInstance().getVolume());
 
@@ -114,8 +112,7 @@ public class DinosaurMenu extends FXGLMenu {
         // Sets the volume label
         Label volumeLabel = new Label(String.format("%.0f%%", settings.getVolume() * 100));
         volumeSlider.valueProperty().addListener((observable, oldValue, newValue) -> {
-        AudioManager.getInstance().setVolume(newValue.doubleValue()); // <--- THIS LINE IS IMPORTANT
-        //mainMenuSound.setVolume(newValue.doubleValue());
+            AudioManager.getInstance().setVolume(newValue.doubleValue()); // <--- THIS LINE IS IMPORTANT
             AudioManager.getInstance().setVolume(newValue.doubleValue());
             settings.setVolume(newValue.doubleValue());
             SettingsProvider.saveSettings(settings);
@@ -213,13 +210,11 @@ public class DinosaurMenu extends FXGLMenu {
 
             startButton.setOnAction(event -> {
                 FXGL.getSceneService().pushSubScene(new ShipSelectionMenu());
-                //mainMenuSound.stop();
             });
 
             imageViewPlaying.setOnMouseClicked(mouseEvent -> {
                 boolean newMutedState = !AudioManager.getInstance().isMuted();
                 AudioManager.getInstance().setMuted(newMutedState); // <--- THIS LINE IS IMPORTANT
-                //mainMenuSound.setMute(newMutedState);
                 settings.setMuted(newMutedState);
                 imageViewPlaying.setImage(newMutedState ? mute : audioOn);
                 SettingsProvider.saveSettings(settings);

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/ShipSelectionMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/ShipSelectionMenu.java
@@ -22,8 +22,6 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
-import javafx.scene.media.Media;
-import javafx.scene.media.MediaPlayer;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
@@ -45,6 +43,7 @@ public class ShipSelectionMenu extends FXGLMenu {
 
         // Background music
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
+        System.out.println("Volume ship selection: "+AudioManager.getInstance().getVolume());
         
 
         // background image

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/ShipSelectionMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/ShipSelectionMenu.java
@@ -46,8 +46,6 @@ public class ShipSelectionMenu extends FXGLMenu {
 
         // Background music
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
-        System.out.println("Volume ship selection: "+AudioManager.getInstance().getVolume());
-        
 
         // background image
         InputStream backGround = getClass().getClassLoader().getResourceAsStream("assets/textures/background.png");

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/ShipSelectionMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/ShipSelectionMenu.java
@@ -3,6 +3,7 @@ package com.dinosaur.dinosaurexploder.view;
 import com.almasb.fxgl.app.scene.FXGLMenu;
 import com.almasb.fxgl.app.scene.MenuType;
 import com.almasb.fxgl.dsl.FXGL;
+import com.almasb.fxgl.scene.Scene;
 import com.almasb.fxgl.ui.FontType;
 import com.dinosaur.dinosaurexploder.exception.LockedShipException;
 import com.dinosaur.dinosaurexploder.constants.GameConstants;
@@ -26,6 +27,8 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
 import com.dinosaur.dinosaurexploder.utils.AudioManager;
+import org.jetbrains.annotations.NotNull;
+
 import java.io.InputStream;
 import java.util.Objects;
 
@@ -206,5 +209,12 @@ public class ShipSelectionMenu extends FXGLMenu {
         System.out.println("Selected Spaceship: " + shipNumber);
         FXGL.getSceneService().pushSubScene(new WeaponSelectionMenu());
       
+    }
+
+    @Override
+    public void onEnteredFrom(@NotNull Scene prevState) {
+        super.onEnteredFrom(prevState);
+        FXGL.getAudioPlayer().stopAllSounds();
+        AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
     }
 }

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/WeaponSelectionMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/WeaponSelectionMenu.java
@@ -44,7 +44,7 @@ public class WeaponSelectionMenu extends FXGLMenu {
 
         // Background music
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
-        
+        System.out.println("Volume weapon selection: "+AudioManager.getInstance().getVolume());
 
         // background image
         InputStream backGround = getClass().getClassLoader().getResourceAsStream("assets/textures/background.png");

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/WeaponSelectionMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/WeaponSelectionMenu.java
@@ -44,7 +44,6 @@ public class WeaponSelectionMenu extends FXGLMenu {
 
         // Background music
         AudioManager.getInstance().playMusic(GameConstants.MAIN_MENU_SOUND);
-        System.out.println("Volume weapon selection: "+AudioManager.getInstance().getVolume());
 
         // background image
         InputStream backGround = getClass().getClassLoader().getResourceAsStream("assets/textures/background.png");


### PR DESCRIPTION
### ✅ PR Checklist

- [x] My PR title follows the format: `[Type]: clear description of change`
- [x] I used the correct `type`: Feature, Fix, Refactor, Docs, Test, Chore
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).


### 📝 What does this PR do?

This PR continues with the implementation of the AudioManager of the PR #207 , it integrates the manager on all game screens and remove bugs where in the navigation between screens sometimes it'd loose the audio, as well it saves and use the audio settings saved from the last time when the game is launched again matching the volume slider.
- ...

### 🔗 Related Issue

> Link to the issue this PR addresses (if any)

- [x] This PR fixes/closes: #146 
- [ ] This PR doesn’t address a specific issue.

### 📸 Screenshots / Demos (if applicable)

> [!NOTE]
> 🦖 No screenshots or demo provided.

### 💬 Extra Notes (Optional)

> [!NOTE]
> 🦕 No extra notes.
