### PR TITLE
[Feature]: Weapon Spam Cooldown 

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java
@@ -171,4 +171,12 @@ public class PlayerComponent extends Component implements Player {
         weaponHeat = Math.max(0.0, weaponHeat - (COOLING_RATE_PER_SECOND * tpf));
     }
 
+    // Getter for weapon heat for fron end feature
+    public double getWeaponHeat() {
+        return weaponHeat; 
+    }
+    public double getWeaponHeatPercentage() {
+        return (weaponHeat / MAX_WEAPON_HEAT) * 100.0;
+    }
+
 }

--- a/src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java
@@ -7,6 +7,7 @@ import com.almasb.fxgl.dsl.FXGL;
 import com.almasb.fxgl.dsl.components.ExpireCleanComponent;
 import com.almasb.fxgl.entity.SpawnData;
 import com.almasb.fxgl.entity.component.Component;
+import com.almasb.fxgl.time.LocalTimer;
 import com.almasb.fxgl.texture.Texture;
 import com.dinosaur.dinosaurexploder.constants.GameConstants;
 import com.dinosaur.dinosaurexploder.interfaces.Player;
@@ -21,12 +22,20 @@ import javafx.util.Duration;
 import java.util.Objects;
 
 public class PlayerComponent extends Component implements Player {
+    private static final double MAX_WEAPON_HEAT = 100.0;
+    private static final double HEAT_PER_SHOT = 12.0;
+    private static final double COOLING_RATE_PER_SECOND = 30.0; // these variables can be adjusted as needed
+    private static final double SLOWDOWN_THRESHOLD = 90.0;
+    private static final double SLOWED_SHOT_COOLDOWN_SECONDS = 0.28;
+
     private final int selectedShip = GameData.getSelectedShip();
     private final int selectedWeapon = GameData.getSelectedWeapon();
     String shipImagePath = "assets/textures/spaceship" + selectedShip + ".png";
     String weaponImagePath = "/assets/textures/projectiles/projectile" + selectedShip + "_" + selectedWeapon + ".png";
     int movementSpeed = 8;
     private boolean isInvincible = false;
+    private double weaponHeat = 0.0;
+    private final LocalTimer shootTimer = FXGL.newLocalTimer();
 
     public void setInvincible(boolean invincible) {
         this.isInvincible = invincible;
@@ -39,6 +48,16 @@ public class PlayerComponent extends Component implements Player {
 
     public boolean isInvincible() {
         return isInvincible;
+    }
+
+    @Override
+    public void onAdded() {
+        shootTimer.capture();
+    }
+
+    @Override
+    public void onUpdate(double tpf) {
+        coolWeapon(tpf);
     }
 
     // entity is not initialized anywhere because it is linked in the factory
@@ -104,6 +123,10 @@ public class PlayerComponent extends Component implements Player {
      * player and spawning of the new bullet
      */
     public void shoot() {
+        if (!canShoot()) { // Implemented cooldown based on weapon heat
+            return;
+        }
+
         AudioManager.getInstance().playSound(GameConstants.SHOOT_SOUND);
         Point2D center = entity.getCenter();
         Vec2 direction = Vec2.fromAngle(entity.getRotation() - 90);
@@ -112,8 +135,10 @@ public class PlayerComponent extends Component implements Player {
 
         spawn("basicProjectile",
                 new SpawnData(center.getX() - (projImg.getWidth() / 2) + 3, center.getY() - 25) // Ajusta según el
-                                                                                                // tamaño de la nave
+                                                                                               // tamaño de la nave
                         .put("direction", direction.toPoint2D()));
+        increaseWeaponHeat();
+        shootTimer.capture();
     }
 
     private void spawnMovementAnimation() {
@@ -123,6 +148,27 @@ public class PlayerComponent extends Component implements Player {
                 .view(new Texture(spcshpImg))
                 .with(new ExpireCleanComponent(Duration.seconds(0.15)).animateOpacity())
                 .buildAndAttach();
+    }
+
+    //Check if the player can shoot based on weapon heat and cooldown
+
+    private boolean canShoot() {
+        if (weaponHeat >= SLOWDOWN_THRESHOLD) {
+            return shootTimer.elapsed(Duration.seconds(SLOWED_SHOT_COOLDOWN_SECONDS));
+        }
+        return true;
+    }
+
+    private void increaseWeaponHeat() {
+        weaponHeat = Math.min(MAX_WEAPON_HEAT, weaponHeat + HEAT_PER_SHOT);
+    }
+
+    private void coolWeapon(double tpf) {
+        if (weaponHeat <= 0) {
+            weaponHeat = 0;
+            return;
+        }
+        weaponHeat = Math.max(0.0, weaponHeat - (COOLING_RATE_PER_SECOND * tpf));
     }
 
 }

--- a/src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java
@@ -7,7 +7,8 @@ import com.almasb.fxgl.dsl.FXGL;
 import com.almasb.fxgl.dsl.components.ExpireCleanComponent;
 import com.almasb.fxgl.entity.SpawnData;
 import com.almasb.fxgl.entity.component.Component;
-import com.almasb.fxgl.time.LocalTimer;
+import com.dinosaur.dinosaurexploder.utils.GameTimer;
+import com.dinosaur.dinosaurexploder.utils.FXGLGameTimer;
 import com.almasb.fxgl.texture.Texture;
 import com.dinosaur.dinosaurexploder.constants.GameConstants;
 import com.dinosaur.dinosaurexploder.interfaces.Player;
@@ -35,7 +36,17 @@ public class PlayerComponent extends Component implements Player {
     int movementSpeed = 8;
     private boolean isInvincible = false;
     private double weaponHeat = 0.0;
-    private final LocalTimer shootTimer = FXGL.newLocalTimer();
+    private final GameTimer shootTimer;
+
+    // Default constructor used by the game (will create an FXGL-backed timer)
+    public PlayerComponent() {
+        this.shootTimer = new FXGLGameTimer();
+    }
+
+    // Test-friendly constructor to inject a mock GameTimer
+    public PlayerComponent(GameTimer shootTimer) {
+        this.shootTimer = shootTimer;
+    }
 
     public void setInvincible(boolean invincible) {
         this.isInvincible = invincible;
@@ -154,7 +165,7 @@ public class PlayerComponent extends Component implements Player {
 
     private boolean canShoot() {
         if (weaponHeat >= SLOWDOWN_THRESHOLD) {
-            return shootTimer.elapsed(Duration.seconds(SLOWED_SHOT_COOLDOWN_SECONDS));
+            return shootTimer.isElapsed(Duration.seconds(SLOWED_SHOT_COOLDOWN_SECONDS));
         }
         return true;
     }

--- a/src/main/java/com/dinosaur/dinosaurexploder/components/WeaponHeatComponent.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/components/WeaponHeatComponent.java
@@ -1,0 +1,33 @@
+package com.dinosaur.dinosaurexploder.components;
+
+import com.almasb.fxgl.entity.component.Component;
+
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
+
+public class WeaponHeatComponent extends Component {
+    private static final double MAX_WIDTH = 100;
+    private static final double SLOWDOWN_THRESHOLD = 90.0;
+
+    private final Rectangle fill;
+    private final PlayerComponent playerComponent;
+
+    public WeaponHeatComponent(Rectangle fill, PlayerComponent playerComponent) {
+        this.fill = fill;
+        this.playerComponent = playerComponent;
+    }
+
+    @Override
+    public void onUpdate(double tpf) {
+        double heatPercent = playerComponent.getWeaponHeatPercentage();
+        fill.setWidth((heatPercent / 100.0) * MAX_WIDTH);
+        fill.setFill(getColorForHeat(heatPercent));
+    }
+
+    private Color getColorForHeat(double percent) {
+        if (percent >= SLOWDOWN_THRESHOLD) return Color.RED;
+        if (percent >= 75) return Color.ORANGE;
+        if (percent >= 50) return Color.YELLOW;
+        return Color.LIMEGREEN;
+    }
+}

--- a/src/main/java/com/dinosaur/dinosaurexploder/constants/EntityType.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/constants/EntityType.java
@@ -4,5 +4,5 @@ package com.dinosaur.dinosaurexploder.constants;
  *  This handles with all the entities in the game like lives, player projectile etc.
  */
 public enum EntityType {
-    PLAYER, GREEN_DINO, RED_DINO, ORANGE_DINO, PROJECTILE, ENEMY_PROJECTILE, SCORE, LIFE, BOMB, COIN, HEART, LEVEL, HEALTHBAR, LEVEL_PROGRESS_BAR
+    PLAYER, GREEN_DINO, RED_DINO, ORANGE_DINO, PROJECTILE, ENEMY_PROJECTILE, SCORE, LIFE, BOMB, COIN, HEART, LEVEL, HEALTHBAR, LEVEL_PROGRESS_BAR, WEAPON_HEAT
 }

--- a/src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameInitializer.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameInitializer.java
@@ -1,11 +1,6 @@
 package com.dinosaur.dinosaurexploder.controller.core;
 
 import com.almasb.fxgl.dsl.FXGL;
-import static com.almasb.fxgl.dsl.FXGL.getAppCenter;
-import static com.almasb.fxgl.dsl.FXGL.getAppHeight;
-import static com.almasb.fxgl.dsl.FXGL.onKey;
-import static com.almasb.fxgl.dsl.FXGL.onKeyDown;
-import static com.almasb.fxgl.dsl.FXGLForKtKt.spawn;
 import com.almasb.fxgl.entity.Entity;
 import com.almasb.fxgl.entity.SpawnData;
 import com.dinosaur.dinosaurexploder.components.BombComponent;
@@ -21,8 +16,12 @@ import com.dinosaur.dinosaurexploder.utils.AudioManager;
 import com.dinosaur.dinosaurexploder.utils.LanguageManager;
 import com.dinosaur.dinosaurexploder.utils.LevelManager;
 import com.dinosaur.dinosaurexploder.utils.SettingsProvider;
-
 import javafx.scene.input.KeyCode;
+
+import static com.almasb.fxgl.dsl.FXGL.*;
+import static com.almasb.fxgl.dsl.FXGL.getAppCenter;
+import static com.almasb.fxgl.dsl.FXGL.getAppHeight;
+import static com.almasb.fxgl.dsl.FXGLForKtKt.spawn;
 
 public class GameInitializer {
 
@@ -91,8 +90,7 @@ public class GameInitializer {
         collectedCoinsComponent = coin.getComponent(CollectedCoinsComponent.class);
         bomb.addComponent(new BombComponent());
         levelProgressBar = spawn("levelProgressBar", new SpawnData(getAppCenter().getX() - 170, getAppCenter().getY() + 340).put("levelManager", levelManager));
-
-        spawn("weaponHeat", new SpawnData(getAppCenter().getX() + 170, getAppCenter().getY() + 340));
+        spawn("weaponHeat", new SpawnData(getAppCenter().getX() + 170, getAppCenter().getY() + 340).put("playerComponent", player.getComponent(PlayerComponent.class)));
     }
 
     public EnemySpawner getEnemySpawner() {

--- a/src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameInitializer.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameInitializer.java
@@ -1,6 +1,11 @@
 package com.dinosaur.dinosaurexploder.controller.core;
 
 import com.almasb.fxgl.dsl.FXGL;
+import static com.almasb.fxgl.dsl.FXGL.getAppCenter;
+import static com.almasb.fxgl.dsl.FXGL.getAppHeight;
+import static com.almasb.fxgl.dsl.FXGL.onKey;
+import static com.almasb.fxgl.dsl.FXGL.onKeyDown;
+import static com.almasb.fxgl.dsl.FXGLForKtKt.spawn;
 import com.almasb.fxgl.entity.Entity;
 import com.almasb.fxgl.entity.SpawnData;
 import com.dinosaur.dinosaurexploder.components.BombComponent;
@@ -16,12 +21,8 @@ import com.dinosaur.dinosaurexploder.utils.AudioManager;
 import com.dinosaur.dinosaurexploder.utils.LanguageManager;
 import com.dinosaur.dinosaurexploder.utils.LevelManager;
 import com.dinosaur.dinosaurexploder.utils.SettingsProvider;
-import javafx.scene.input.KeyCode;
 
-import static com.almasb.fxgl.dsl.FXGL.*;
-import static com.almasb.fxgl.dsl.FXGL.getAppCenter;
-import static com.almasb.fxgl.dsl.FXGL.getAppHeight;
-import static com.almasb.fxgl.dsl.FXGLForKtKt.spawn;
+import javafx.scene.input.KeyCode;
 
 public class GameInitializer {
 
@@ -90,6 +91,8 @@ public class GameInitializer {
         collectedCoinsComponent = coin.getComponent(CollectedCoinsComponent.class);
         bomb.addComponent(new BombComponent());
         levelProgressBar = spawn("levelProgressBar", new SpawnData(getAppCenter().getX() - 170, getAppCenter().getY() + 340).put("levelManager", levelManager));
+
+        spawn("weaponHeat", new SpawnData(getAppCenter().getX() + 170, getAppCenter().getY() + 340));
     }
 
     public EnemySpawner getEnemySpawner() {

--- a/src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java
@@ -1,11 +1,7 @@
 package com.dinosaur.dinosaurexploder.model;
 
-import java.util.Objects;
-
 import com.almasb.fxgl.dsl.EntityBuilder;
 import com.almasb.fxgl.dsl.FXGL;
-import static com.almasb.fxgl.dsl.FXGLForKtKt.getGameWorld;
-import static com.almasb.fxgl.dsl.FXGLForKtKt.texture;
 import com.almasb.fxgl.dsl.components.ExpireCleanComponent;
 import com.almasb.fxgl.dsl.components.OffscreenCleanComponent;
 import com.almasb.fxgl.dsl.components.ProjectileComponent;
@@ -18,23 +14,13 @@ import com.almasb.fxgl.physics.BoundingShape;
 import com.almasb.fxgl.physics.HitBox;
 import com.almasb.fxgl.texture.AnimatedTexture;
 import com.almasb.fxgl.texture.AnimationChannel;
-import com.dinosaur.dinosaurexploder.components.BombComponent;
-import com.dinosaur.dinosaurexploder.components.CoinComponent;
-import com.dinosaur.dinosaurexploder.components.CollectedCoinsComponent;
-import com.dinosaur.dinosaurexploder.components.GreenDinoComponent;
-import com.dinosaur.dinosaurexploder.components.HealthbarComponent;
-import com.dinosaur.dinosaurexploder.components.Heart;
-import com.dinosaur.dinosaurexploder.components.LevelProgressBarComponent;
-import com.dinosaur.dinosaurexploder.components.LifeComponent;
-import com.dinosaur.dinosaurexploder.components.OrangeDinoComponent;
-import com.dinosaur.dinosaurexploder.components.PlayerComponent;
-import com.dinosaur.dinosaurexploder.components.RedDinoComponent;
-import com.dinosaur.dinosaurexploder.components.ScoreComponent;
+import com.dinosaur.dinosaurexploder.components.*;
+
 import com.dinosaur.dinosaurexploder.constants.EntityType;
 import com.dinosaur.dinosaurexploder.constants.GameConstants;
 import com.dinosaur.dinosaurexploder.utils.FXGLGameTimer;
 import com.dinosaur.dinosaurexploder.utils.LevelManager;
-
+import com.dinosaur.dinosaurexploder.components.PlayerComponent;
 import javafx.geometry.Orientation;
 import javafx.geometry.Point2D;
 import javafx.scene.Group;
@@ -45,6 +31,10 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.util.Duration;
+
+import java.util.Objects;
+
+import static com.almasb.fxgl.dsl.FXGLForKtKt.*;
 
 /**
  * Summary :
@@ -332,17 +322,21 @@ public class GameEntityFactory implements EntityFactory {
     }
     @Spawns("weaponHeat")
     public Entity newWeaponHeat(SpawnData data) {
-    // TEMPORARY: Just a visible rectangle to test positioning
-    Rectangle background = new Rectangle(100, 15, Color.DARKGRAY);
-    Rectangle fill = new Rectangle(50, 13, Color.ORANGE);  // 50% filled for visibility
-    fill.setLayoutX(1);
-    fill.setLayoutY(1);
-    Group heatBar = new Group(background, fill);
+        PlayerComponent playerComponent = data.get("playerComponent");
 
-    return entityBuilderBase(data, EntityType.WEAPON_HEAT)
-            .view(heatBar)
-            // NO component yet - just testing visual placement
-            .build();
+        Rectangle background = new Rectangle(100, 15, Color.DARKGRAY);
+        background.setStroke(Color.GRAY);
+        background.setStrokeWidth(1);
+
+        Rectangle fill = new Rectangle(0, 13, Color.LIMEGREEN);  // ← Start at 0 width
+        fill.setLayoutX(1);
+        fill.setLayoutY(1);
+        Group heatBar = new Group(background, fill);
+
+        return entityBuilderBase(data, EntityType.WEAPON_HEAT)
+                .view(heatBar)
+                .with(new WeaponHeatComponent(fill, playerComponent))  // ← Add component
+                .build();
 }
 
     /**

--- a/src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java
@@ -1,7 +1,11 @@
 package com.dinosaur.dinosaurexploder.model;
 
+import java.util.Objects;
+
 import com.almasb.fxgl.dsl.EntityBuilder;
 import com.almasb.fxgl.dsl.FXGL;
+import static com.almasb.fxgl.dsl.FXGLForKtKt.getGameWorld;
+import static com.almasb.fxgl.dsl.FXGLForKtKt.texture;
 import com.almasb.fxgl.dsl.components.ExpireCleanComponent;
 import com.almasb.fxgl.dsl.components.OffscreenCleanComponent;
 import com.almasb.fxgl.dsl.components.ProjectileComponent;
@@ -14,13 +18,23 @@ import com.almasb.fxgl.physics.BoundingShape;
 import com.almasb.fxgl.physics.HitBox;
 import com.almasb.fxgl.texture.AnimatedTexture;
 import com.almasb.fxgl.texture.AnimationChannel;
-import com.dinosaur.dinosaurexploder.components.*;
-
+import com.dinosaur.dinosaurexploder.components.BombComponent;
+import com.dinosaur.dinosaurexploder.components.CoinComponent;
+import com.dinosaur.dinosaurexploder.components.CollectedCoinsComponent;
+import com.dinosaur.dinosaurexploder.components.GreenDinoComponent;
+import com.dinosaur.dinosaurexploder.components.HealthbarComponent;
+import com.dinosaur.dinosaurexploder.components.Heart;
+import com.dinosaur.dinosaurexploder.components.LevelProgressBarComponent;
+import com.dinosaur.dinosaurexploder.components.LifeComponent;
+import com.dinosaur.dinosaurexploder.components.OrangeDinoComponent;
+import com.dinosaur.dinosaurexploder.components.PlayerComponent;
+import com.dinosaur.dinosaurexploder.components.RedDinoComponent;
+import com.dinosaur.dinosaurexploder.components.ScoreComponent;
 import com.dinosaur.dinosaurexploder.constants.EntityType;
 import com.dinosaur.dinosaurexploder.constants.GameConstants;
 import com.dinosaur.dinosaurexploder.utils.FXGLGameTimer;
 import com.dinosaur.dinosaurexploder.utils.LevelManager;
-import com.dinosaur.dinosaurexploder.components.PlayerComponent;
+
 import javafx.geometry.Orientation;
 import javafx.geometry.Point2D;
 import javafx.scene.Group;
@@ -31,10 +45,6 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.util.Duration;
-
-import java.util.Objects;
-
-import static com.almasb.fxgl.dsl.FXGLForKtKt.*;
 
 /**
  * Summary :
@@ -320,6 +330,20 @@ public class GameEntityFactory implements EntityFactory {
                 .with(new LevelProgressBarComponent(filled, levelManager))
                 .build();
     }
+    @Spawns("weaponHeat")
+    public Entity newWeaponHeat(SpawnData data) {
+    // TEMPORARY: Just a visible rectangle to test positioning
+    Rectangle background = new Rectangle(100, 15, Color.DARKGRAY);
+    Rectangle fill = new Rectangle(50, 13, Color.ORANGE);  // 50% filled for visibility
+    fill.setLayoutX(1);
+    fill.setLayoutY(1);
+    Group heatBar = new Group(background, fill);
+
+    return entityBuilderBase(data, EntityType.WEAPON_HEAT)
+            .view(heatBar)
+            // NO component yet - just testing visual placement
+            .build();
+}
 
     /**
      * Summary :

--- a/src/test/java/com/dinosaur/dinosaurexploder/model/WeaponHeatTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/model/WeaponHeatTest.java
@@ -1,0 +1,101 @@
+package com.dinosaur.dinosaurexploder.model;
+
+import com.dinosaur.dinosaurexploder.components.PlayerComponent;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WeaponHeatTest {
+
+    // Helper to call a private no-arg method on PlayerComponent
+    private void invokePrivateNoArg(PlayerComponent pc, String methodName, Class<?>... paramTypes) throws Exception {
+        Method m = PlayerComponent.class.getDeclaredMethod(methodName, paramTypes);
+        m.setAccessible(true);
+        m.invoke(pc);
+    }
+
+    private void invokePrivate(PlayerComponent pc, String methodName, Object... args) throws Exception {
+        Class<?>[] paramTypes = new Class[args.length];
+        for (int i = 0; i < args.length; i++) paramTypes[i] = args[i].getClass();
+        Method m = PlayerComponent.class.getDeclaredMethod(methodName, paramTypes);
+        m.setAccessible(true);
+        m.invoke(pc, args);
+    }
+
+    private void setWeaponHeat(PlayerComponent pc, double value) throws Exception {
+        Field f = PlayerComponent.class.getDeclaredField("weaponHeat");
+        f.setAccessible(true);
+        f.setDouble(pc, value);
+    }
+
+    private double getWeaponHeat(PlayerComponent pc) throws Exception {
+        Method m = PlayerComponent.class.getDeclaredMethod("getWeaponHeat");
+        m.setAccessible(true);
+        return (double) m.invoke(pc);
+    }
+
+    @Test
+    void testIncreaseWeaponHeatAndMax() throws Exception {
+    var pc = new PlayerComponent(new com.dinosaur.dinosaurexploder.utils.MockGameTimer());
+
+        // Call increaseWeaponHeat 10 times -> should cap at MAX_WEAPON_HEAT (100)
+        for (int i = 0; i < 10; i++) {
+            invokePrivateNoArg(pc, "increaseWeaponHeat");
+        }
+
+        double heat = getWeaponHeat(pc);
+        assertTrue(heat <= 100.0, "Weapon heat should not exceed 100");
+        assertEquals(100.0, heat, 0.0001, "Weapon heat should be exactly capped at 100 after repeated increases");
+    }
+
+    @Test
+    void testCoolingOverTime() throws Exception {
+    var pc = new PlayerComponent(new com.dinosaur.dinosaurexploder.utils.MockGameTimer());
+
+        // set heat to 80
+        setWeaponHeat(pc, 80.0);
+
+        // coolWeapon expects tpf (time per frame). COOLING_RATE_PER_SECOND = 30.0
+        // calling coolWeapon with tpf=1.0 should reduce heat by 30
+        Method cool = PlayerComponent.class.getDeclaredMethod("coolWeapon", double.class);
+        cool.setAccessible(true);
+        cool.invoke(pc, 1.0);
+
+        double heatAfter = getWeaponHeat(pc);
+        assertEquals(50.0, heatAfter, 0.0001, "Weapon should have cooled by 30 after 1s equivalent tpf");
+    }
+
+    @Test
+    void testCanShootSlowedCooldownBehavior() throws Exception {
+    var pc = new PlayerComponent(new com.dinosaur.dinosaurexploder.utils.MockGameTimer());
+
+        // set heat above slowdown threshold
+        setWeaponHeat(pc, 95.0);
+
+        // Access private canShoot method
+        Method canShoot = PlayerComponent.class.getDeclaredMethod("canShoot");
+        canShoot.setAccessible(true);
+
+    // Use the MockGameTimer to control elapsed time
+    Field shootTimerField = PlayerComponent.class.getDeclaredField("shootTimer");
+    shootTimerField.setAccessible(true);
+    com.dinosaur.dinosaurexploder.utils.MockGameTimer mockTimer = (com.dinosaur.dinosaurexploder.utils.MockGameTimer) shootTimerField.get(pc);
+
+    // capture at time zero
+    mockTimer.capture();
+
+    // Immediately after capture, canShoot() should return false because not enough time elapsed
+    boolean immediate = (boolean) canShoot.invoke(pc);
+    assertFalse(immediate, "When weapon heat is above threshold and timer just captured, player should NOT be able to shoot immediately");
+
+    // Advance simulated time slightly more than the slowed cooldown (0.28s)
+    mockTimer.advance(javafx.util.Duration.millis(320));
+
+    boolean afterWait = (boolean) canShoot.invoke(pc);
+    assertTrue(afterWait, "After the slowed cooldown time has passed, player should be able to shoot again");
+    }
+
+}


### PR DESCRIPTION
### ✅ PR Checklist

<!-- ✅ To check a box, write: `[x]` (no space between the brackets) -->

- [x] My PR title follows the format: `[Type]: clear description of change`
- [x] I used the correct `type`: Feature, Fix, Refactor, Docs, Test, Chore
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).


## 📝 What does this PR do?

**Description:**
This PR implements a weapon overheating/cooldown system to prevent spam shooting and improve gameplay balance. When players continuously fire their weapon, it heats up and eventually becomes rate-limited, forcing strategic shooting rather than constant spam. A color-coded heat bar (green → yellow → orange → red) provides real-time visual feedback so players can manage their fire rate strategically. Players can shoot freely until reaching 90% heat, at which point the firing rate is significantly reduced. The weapon automatically cools down when not in use.

**Files Changes**

**New Files**
`src/test/java/com/dinosaur/dinosaurexploder/mode/WeaponHeatTest.java`
`src/main/java/com/dinosaur/dinosaurexploder/components/WeaponHeatComponent.java`

**Modified Files**
`src/main/java/com/dinosaur/dinosaurexploder/components/PlayerComponent.java`
`src/main/java/com/dinosaur/dinosaurexploder/constants/EntityType.java`
`src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameInitializer.java`
`src/main/java/com/dinosaur/dinosaurexploder/model/GameEntityFactory.java`

## **Implementation Details**

### **Backend**

Implemented weapon overheating mechanics with fast-fire below 90 heat and slowed fire within the 90–100 heat range. This implementation prevents players from spamming the entire game by reducing shooting speed and encourages a more strategic play within levels.

**PlayerComponent** (`components/PlayerComponent.java`)
- Added heat tracking fields: MAX_WEAPON_HEAT (100), HEAT_PER_SHOT (12), COOLING_RATE_PER_SECOND (30), SLOWDOWN_THRESHOLD (90), SLOWED_SHOT_COOLDOWN_SECONDS (0.28), weaponHeat state
- HEAT_PER_SHOT manages how much the weapon heats up per shot
- COOLING_RATE_PER_SECOND manages how fast the weapon cools down.
- “canShoot()” checks whether the cooldown is applied to the shooting in which case the player cannot spam.
- ”increaseWeaponHeat()” is called each shot to heat up the weapon.
- “coolWeapon()” runs every second to reduce weapon heat at a specified cooling rate.
- ”getWeaponHeatPercentage()” returns the percent of current heat out of the MAX_WEAPON_HEAT


### **Frontend**
Implemented a real-time weapon heat visualization that integrates with the backend cooldown mechanics from `PlayerComponent`. The heat bar provides immediate visual feedback to players about their weapon heat status and firing rate limitations.

Followed the existing FXGL entity-component pattern used throughout the repo:

**WeaponHeatComponent** (`components/WeaponHeatComponent.java`)
- Extends `Component` to leverage FXGL's automatic `onUpdate()` lifecycle
- Receives `PlayerComponent` reference via constructor to access `getWeaponHeatPercentage()`
- Updates bar width and color dynamically based on heat level (0-100%)
- Color thresholds align with backend behavior:
- 0-49%: Green (normal operation)
- 50-74%: Yellow (moderate heat)
- 75-89%: Orange (high heat)
- 90-100%: Red (rate-limited, matches backend `SLOWDOWN_THRESHOLD`)

**Entity Factory Integration** (`model/GameEntityFactory.java`)
- Added `@Spawns("weaponHeat")` method following the same pattern as `levelProgressBar`
- Creates visual bar using JavaFX `Rectangle` components (background + fill)
- Receives `PlayerComponent` via `SpawnData` to establish connection to backend

**Game Initialization** (`controller/core/GameInitializer.java`)
- Spawns heat bar in `initGameEntities()` alongside other HUD elements
- Positioned on bottom right side of screen to balance with level progress bar on left

**Type Registration** (`constants/EntityType.java`)
- Added `WEAPON_HEAT` enum value for entity type safety


### **Testing**
Adds unit tests for the Weapon Heat feature and makes PlayerComponent test-friendly by introducing a timer abstraction that can be injected for testing. This lets tests simulate time deterministically (no FXGL engine required) and verifies heat increase, capping, cooling, and slowed-cooldown shooting behavior.

**WeaponHeatTest.java implements three tests:**
- testIncreaseWeaponHeatAndMax: invokes private increaseWeaponHeat() multiple times via reflection and asserts heat is capped at 100.
- testCoolingOverTime: sets private weaponHeat to 80, calls private coolWeapon(1.0) and asserts heat decreased by the cooling rate (30 per second).
- testCanShootSlowedCooldownBehavior: injects MockGameTimer into PlayerComponent, sets weaponHeat above slowdown threshold, captures timer, asserts canShoot() is false immediately, then advances the mock timer and asserts canShoot() becomes true after the slowed cooldown period.

**Timer Added**
- Introduced use of the existing GameTimer abstraction (and FXGLGameTimer for runtime).
- This is only a behavior/API change inside PlayerComponent
- A test (or the runtime) can now supply a GameTimer implementation.
- For tests, MockGameTimer (already present in src/test/java/.../utils) is used to drive time deterministically, avoiding dependence on FXGL engine initialization.
- No runtime change in behavior: default constructor uses FXGLGameTimer, preserving existing behavior in the running game.

**How it works**
- PlayerComponent now holds a GameTimer shootTimer. The production constructor uses FXGLGameTimer which delegates to FXGL's LocalTimer. Tests instantiate PlayerComponent with MockGameTimer.
- The tests manipulate internal weapon state (via reflection) and call private methods directly where no public API existed:
  - increaseWeaponHeat() is invoked repeatedly to check capping at MAX_WEAPON_HEAT.
  - coolWeapon(tpf) is invoked with a known tpf to assert deterministic cooling.
  - canShoot() is invoked while controlling time through MockGameTimer to verify slowed cooldown behavior when weapon heat exceeds SLOWDOWN_THRESHOLD.
  - This pattern keeps runtime code unchanged while enabling deterministic, fast unit tests that don't require an FXGL engine.
 
**How to run the tests locally**
 - Run only the new tests: `mvn -Dtest=com.dinosaur.dinosaurexploder.model.WeaponHeatTest test`
 - Run Full Test Suite: `mvn test`


### 🔗 Related Issue

> Link to the issue this PR addresses (if any): https://github.com/jvondermarck/dinosaur-exploder/issues/133


- [x] This PR fixes/closes: Fixes #133
- [ ] This PR doesn’t address a specific issue.

### 📸 Screenshots / Demos (if applicable)


https://github.com/user-attachments/assets/3eecc44a-1f84-4cd7-a032-2c14772f3e95



### 💬 Extra Notes (Optional)
In our testing, the current values felt good for not making them game too difficult but still limiting spamming and requiring strategy; however, if any of these want to be adjusted, they easily can through the heat tracking fields in `components/PlayerComponent.java`.





