### PR TITLE
[Feature]: Show language names in their native language

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/utils/LanguageManager.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/utils/LanguageManager.java
@@ -14,19 +14,30 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
 public class LanguageManager {
-  private final StringProperty selectedLanguage = new SimpleStringProperty("English");
+
+  public static final String DEFAULT_LANGUAGE = "English";
+  private final StringProperty selectedLanguage = new SimpleStringProperty(DEFAULT_LANGUAGE);
   private Map<String, String> translations = new HashMap<>();
   private static final Map<String, String> NATIVE_LANGUAGE_NAMES =
       Map.of(
-          "English", "English",
-          "French", "Français",
-          "German", "Deutsch",
-          "Spanish", "Español",
-          "Japanese", "日本語",
-          "Russian", "Русский",
-          "Portuguese", "Português",
-          "Greek", "Ελληνικά",
-          "Bulgarian", "Български");
+          DEFAULT_LANGUAGE,
+          DEFAULT_LANGUAGE,
+          "French",
+          "Français",
+          "German",
+          "Deutsch",
+          "Spanish",
+          "Español",
+          "Japanese",
+          "日本語",
+          "Russian",
+          "Русский",
+          "Portuguese",
+          "Português",
+          "Greek",
+          "Ελληνικά",
+          "Bulgarian",
+          "Български");
 
   private static final String RESOURCE_PATH_SEPARATOR = "/"; // Always forward slash for classpath
   private static final String TRANSLATION_PATH_NO_SLASH = "assets/translation/";
@@ -43,7 +54,7 @@ public class LanguageManager {
   public static synchronized LanguageManager getInstance() {
     if (languageManager == null) {
       languageManager = new LanguageManager();
-      languageManager.setSelectedLanguage("English");
+      languageManager.setSelectedLanguage(DEFAULT_LANGUAGE);
     }
     return languageManager;
   }

--- a/src/main/java/com/dinosaur/dinosaurexploder/utils/LanguageManager.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/utils/LanguageManager.java
@@ -16,18 +16,17 @@ import javafx.beans.property.StringProperty;
 public class LanguageManager {
   private final StringProperty selectedLanguage = new SimpleStringProperty("English");
   private Map<String, String> translations = new HashMap<>();
-    private static final Map<String, String> NATIVE_LANGUAGE_NAMES =
-            Map.of(
-                    "English", "English",
-                    "French", "Français",
-                    "German", "Deutsch",
-                    "Spanish", "Español",
-                    "Japanese", "日本語",
-                    "Russian", "Русский",
-                    "Portuguese", "Português",
-                    "Greek", "Ελληνικά",
-                    "Bulgarian", "Български"
-            );
+  private static final Map<String, String> NATIVE_LANGUAGE_NAMES =
+      Map.of(
+          "English", "English",
+          "French", "Français",
+          "German", "Deutsch",
+          "Spanish", "Español",
+          "Japanese", "日本語",
+          "Russian", "Русский",
+          "Portuguese", "Português",
+          "Greek", "Ελληνικά",
+          "Bulgarian", "Български");
 
   private static final String RESOURCE_PATH_SEPARATOR = "/"; // Always forward slash for classpath
   private static final String TRANSLATION_PATH_NO_SLASH = "assets/translation/";
@@ -74,10 +73,11 @@ public class LanguageManager {
     return languages;
   }
 
-  //Returns the language name in the native word (ex. English->English, Spanish->Español). Default returns word in english
-    public String getNativeLanguageName(String language) {
-        return NATIVE_LANGUAGE_NAMES.getOrDefault(language, language);
-    }
+  // Returns the language name in the native word (ex. English->English, Spanish->Español). Default
+  // returns word in english
+  public String getNativeLanguageName(String language) {
+    return NATIVE_LANGUAGE_NAMES.getOrDefault(language, language);
+  }
 
   // Check if the application is running inside a JAR
   private boolean isRunningInsideJar() {

--- a/src/main/java/com/dinosaur/dinosaurexploder/utils/LanguageManager.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/utils/LanguageManager.java
@@ -16,6 +16,18 @@ import javafx.beans.property.StringProperty;
 public class LanguageManager {
   private final StringProperty selectedLanguage = new SimpleStringProperty("English");
   private Map<String, String> translations = new HashMap<>();
+    private static final Map<String, String> NATIVE_LANGUAGE_NAMES =
+            Map.of(
+                    "English", "English",
+                    "French", "Français",
+                    "German", "Deutsch",
+                    "Spanish", "Español",
+                    "Japanese", "日本語",
+                    "Russian", "Русский",
+                    "Portuguese", "Português",
+                    "Greek", "Ελληνικά",
+                    "Bulgarian", "Български"
+            );
 
   private static final String RESOURCE_PATH_SEPARATOR = "/"; // Always forward slash for classpath
   private static final String TRANSLATION_PATH_NO_SLASH = "assets/translation/";
@@ -61,6 +73,11 @@ public class LanguageManager {
     LOGGER.log(Level.INFO, "Available languages: {0}", languages);
     return languages;
   }
+
+  //Returns the language name in the native word (ex. English->English, Spanish->Español). Default returns word in english
+    public String getNativeLanguageName(String language) {
+        return NATIVE_LANGUAGE_NAMES.getOrDefault(language, language);
+    }
 
   // Check if the application is running inside a JAR
   private boolean isRunningInsideJar() {

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -19,10 +19,7 @@ import javafx.animation.Interpolator;
 import javafx.animation.TranslateTransition;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.Label;
-import javafx.scene.control.Slider;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.StackPane;
@@ -171,7 +168,24 @@ public class DinosaurMenu extends FXGLMenu {
       changeLanguage(settings.getLanguage());
     }
 
-    applyStylesheet(languageComboBox);
+        //Define what text is drawn, keeping orignal item value (Draws text->"Français" while item value->"French"
+      languageComboBox.setCellFactory(cb -> new ListCell<>() {
+          @Override
+          protected void updateItem(String item, boolean empty) {
+              super.updateItem(item, empty);
+              setText(empty || item == null ? null : languageManager.getNativeLanguageName(item));
+          }
+      });
+
+      languageComboBox.setButtonCell(new ListCell<>() {
+          @Override
+          protected void updateItem(String item, boolean empty) {
+              super.updateItem(item, empty);
+              setText(empty || item == null ? null : languageManager.getNativeLanguageName(item));
+          }
+      });
+
+      applyStylesheet(languageComboBox);
     languageComboBox.setOnAction(
         event -> {
           changeLanguage(languageComboBox.getValue());

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -168,24 +168,28 @@ public class DinosaurMenu extends FXGLMenu {
       changeLanguage(settings.getLanguage());
     }
 
-        //Define what text is drawn, keeping orignal item value (Draws text->"Français" while item value->"French"
-      languageComboBox.setCellFactory(cb -> new ListCell<>() {
+    // Define what text is drawn, keeping orignal item value (Draws text->"Français" while item
+    // value->"French"
+    languageComboBox.setCellFactory(
+        cb ->
+            new ListCell<>() {
+              @Override
+              protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(empty || item == null ? null : languageManager.getNativeLanguageName(item));
+              }
+            });
+
+    languageComboBox.setButtonCell(
+        new ListCell<>() {
           @Override
           protected void updateItem(String item, boolean empty) {
-              super.updateItem(item, empty);
-              setText(empty || item == null ? null : languageManager.getNativeLanguageName(item));
+            super.updateItem(item, empty);
+            setText(empty || item == null ? null : languageManager.getNativeLanguageName(item));
           }
-      });
+        });
 
-      languageComboBox.setButtonCell(new ListCell<>() {
-          @Override
-          protected void updateItem(String item, boolean empty) {
-              super.updateItem(item, empty);
-              setText(empty || item == null ? null : languageManager.getNativeLanguageName(item));
-          }
-      });
-
-      applyStylesheet(languageComboBox);
+    applyStylesheet(languageComboBox);
     languageComboBox.setOnAction(
         event -> {
           changeLanguage(languageComboBox.getValue());

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/DinosaurMenu.java
@@ -1,6 +1,7 @@
 package com.dinosaur.dinosaurexploder.view;
 
 import static com.almasb.fxgl.dsl.FXGLForKtKt.getUIFactoryService;
+import static com.dinosaur.dinosaurexploder.utils.LanguageManager.DEFAULT_LANGUAGE;
 
 import com.almasb.fxgl.app.scene.FXGLMenu;
 import com.almasb.fxgl.app.scene.MenuType;
@@ -162,7 +163,8 @@ public class DinosaurMenu extends FXGLMenu {
     languageComboBox.setPrefWidth(ComboBox.USE_COMPUTED_SIZE);
     languageComboBox.setMinWidth(ComboBox.USE_COMPUTED_SIZE);
 
-    languageComboBox.setValue(settings.getLanguage() != null ? settings.getLanguage() : "English");
+    languageComboBox.setValue(
+        settings.getLanguage() != null ? settings.getLanguage() : DEFAULT_LANGUAGE);
 
     if (settings.getLanguage() != null) {
       changeLanguage(settings.getLanguage());


### PR DESCRIPTION
<!--
🎉 Thanks for contributing to Dinosaur Exploder!

🚩⚠️ Before submitting your pull request, look at the different hidden HTML comments "<!-- ..." to guide how on to write this Pull Request and understand how to respect the guidelines of the Pull Request template.

After you open the PR, a maintainer will need to approve the GitHub Actions before they can run.
Once approved, GitHub will automatically check if the project builds and runs correctly.
You’ll also see a message from the GitHub bot with a downloadable .jar file — so you can test the game directly from your own work! Pretty cool, right? 😊
-->

### ✅ PR Checklist

> [!TIP]
> Please check the boxes below to confirm you followed the contribution guidelines:

<!-- ✅ To check a box, write: `[x]` (no space between the brackets) -->

- [x] My PR title follows the format: `[Feature]: clear description of change`
- [x] I used the correct `type`: Feature
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).


### 📝 What does this PR do?

- Updates the language selector to display language names in their native language
  (e.g. Français, Deutsch, Español) while keeping the internal language keys unchanged.
- Improves usability for non-English speakers without affecting existing language
  loading or settings persistence.


### 🔗 Related Issue

> [Link to the issue #291](https://github.com/jvondermarck/dinosaur-exploder/issues/291)

<!-- To close an issue automatically when the PR is merged, use the format: `Fixes #<issue-number>` -->
<!-- ✅ To check a box, write: `[x]` (no space between the brackets) -->

- [x] Fixes #291 
- [ ] This PR doesn’t address a specific issue.

### 📸 Screenshots / Demos (if applicable)
<img width="540" height="739" alt="Screenshot 2026-01-10 at 4 49 56 p m" src="https://github.com/user-attachments/assets/6af4d37d-1150-47f3-ba7c-4850c4fed914" />

<!-- Add screenshots, screen recordings, or describe how to test the changes -->
<!-- TIP: You can drag and drop an image or video directly into this box on GitHub to attach it -->

<!-- Please delete the two lines below (used by default) if you want to add a picture/video. -->


### 💬 Extra Notes (Optional)

<!-- Anything else you'd like to add? Questions, a review about what you think of this repo, what it could be improved, how did you find this repo... Any fun facts you want -->

This approach keeps internal language identifiers unchanged to avoid breaking
existing translation loading logic, while improving clarity and accessibility
for users selecting their language.


---

❤️ Thanks again for your contribution to Dinosaur Exploder!  
Your efforts help make this project awesome for everyone. 🦖✨