### PR TITLE
feat(seo): enhance sitemap and robots.txt with i18n alternates (#345)

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_SITE_URL=https://dinosaur-exploder.vercel.app

--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -1,0 +1,16 @@
+import { MetadataRoute } from 'next'
+
+/**
+ * Generates the robots.txt file for the application.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dinosaur-exploder.vercel.app'
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  }
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,32 @@
+import { MetadataRoute } from 'next'
+import { i18n } from '../i18n-config'
+
+/**
+ * Generates a dynamic sitemap for the application.
+ * Supports multiple locales and includes alternate language references (hreflang) for SEO.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://dinosaur-exploder.vercel.app'
+  const routes = ['', '/contact', '/credits', '/how-game-works']
+
+  return i18n.locales.flatMap((locale) =>
+    routes.map((route) => {
+      const url = `${baseUrl}/${locale}${route}`
+      
+      return {
+        url,
+        lastModified: new Date(),
+        changeFrequency: 'monthly',
+        priority: route === '' ? 1 : 0.8,
+        alternates: {
+          languages: Object.fromEntries(
+            i18n.locales.map((lang) => [
+              lang.replace('_', '-'), // Normalize locale for hreflang (e.g., zh_cn -> zh-cn)
+              `${baseUrl}/${lang}${route}`
+            ])
+          ),
+        },
+      }
+    })
+  )
+}


### PR DESCRIPTION
## 🚀 Summary

Improves the dynamic sitemap and robots.txt implementation for better SEO, multilingual support, and scalability.

---

## 📝 What does this PR do?

- Implements dynamic sitemap using Next.js MetadataRoute
- Adds hreflang (alternate language) support for all locales (`en`, `el`, `zh_cn`)
- Uses `NEXT_PUBLIC_SITE_URL` for correct absolute URLs
- Normalizes locale format (`zh_cn` → `zh-cn`)
- Updates robots.txt to dynamically reference sitemap

---

## 🔗 Related Issue

Closes #345

---

## 🧪 Verification

- Ran `npm run build` successfully
- Verified `/sitemap.xml` and `/robots.txt`
- Confirmed:
  - All localized URLs are present
  - No localhost URLs
  - Alternates are correctly generated

---

## 💬 Extra Notes

- Introduces `NEXT_PUBLIC_SITE_URL` environment variable
- Added `.env.example` for configuration reference