### PR TITLE
refactor(audio): centralize volume type behavior (#322)

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/components/AudioControlsComponent.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/components/AudioControlsComponent.java
@@ -30,8 +30,34 @@ public class AudioControlsComponent {
 
   /** Volume types supported by the audio system. */
   public enum VolumeType {
-    MUSIC, // background music
-    SFX // sound effects
+    MUSIC {
+      @Override
+      double getVolume(Settings settings) {
+        return settings.getVolume();
+      }
+
+      @Override
+      void updateVolume(Settings settings, double volume) {
+        AudioManager.getInstance().setVolume(volume);
+        settings.setVolume(volume);
+      }
+    },
+    SFX {
+      @Override
+      double getVolume(Settings settings) {
+        return settings.getSfxVolume();
+      }
+
+      @Override
+      void updateVolume(Settings settings, double volume) {
+        AudioManager.getInstance().setSfxVolume(volume);
+        settings.setSfxVolume(volume);
+      }
+    };
+
+    abstract double getVolume(Settings settings);
+
+    abstract void updateVolume(Settings settings, double volume);
   }
 
   /**
@@ -76,8 +102,7 @@ public class AudioControlsComponent {
   public static Slider createVolumeSlider(VolumeType type, Settings settings, Double maxWidth) {
     Slider slider = new Slider(SLIDER_MIN, SLIDER_MAX, SLIDER_MAX);
 
-    double initialValue =
-        (type == VolumeType.MUSIC) ? settings.getVolume() : settings.getSfxVolume();
+    double initialValue = type.getVolume(settings);
     slider.adjustValue(initialValue);
     slider.setBlockIncrement(SLIDER_INCREMENT);
 
@@ -103,8 +128,7 @@ public class AudioControlsComponent {
    * @return Label that shows volume percentage
    */
   public static Label createVolumeLabel(Slider slider, VolumeType type, Settings settings) {
-    double initialVolume =
-        (type == VolumeType.MUSIC) ? settings.getVolume() : settings.getSfxVolume();
+    double initialVolume = type.getVolume(settings);
 
     Label label = new Label(String.format(LABEL_FORMAT, initialVolume * 100));
     label.setStyle("-fx-text-fill: #61C181;");
@@ -148,13 +172,7 @@ public class AudioControlsComponent {
             (observable, oldValue, newValue) -> {
               double volume = newValue.doubleValue();
 
-              if (type == VolumeType.MUSIC) {
-                AudioManager.getInstance().setVolume(volume);
-                settings.setVolume(volume);
-              } else {
-                AudioManager.getInstance().setSfxVolume(volume);
-                settings.setSfxVolume(volume);
-              }
+              type.updateVolume(settings, volume);
 
               SettingsProvider.saveSettings(settings);
 

--- a/src/test/java/com/dinosaur/dinosaurexploder/components/AudioControlsComponentTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/components/AudioControlsComponentTest.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.dinosaur.dinosaurexploder.components;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.dinosaur.dinosaurexploder.model.Settings;
+import org.junit.jupiter.api.Test;
+
+class AudioControlsComponentTest {
+
+  @Test
+  void volumeTypesReadTheirConfiguredSettings() {
+    Settings settings = new Settings();
+    settings.setVolume(0.25);
+    settings.setSfxVolume(0.75);
+
+    assertEquals(0.25, AudioControlsComponent.VolumeType.MUSIC.getVolume(settings));
+    assertEquals(0.75, AudioControlsComponent.VolumeType.SFX.getVolume(settings));
+  }
+}

--- a/src/test/java/com/dinosaur/dinosaurexploder/components/GameControlsComponentTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/components/GameControlsComponentTest.java
@@ -6,6 +6,7 @@
 package com.dinosaur.dinosaurexploder.components;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.dinosaur.dinosaurexploder.constants.GameMode;
 import com.dinosaur.dinosaurexploder.model.GameData;
@@ -56,5 +57,25 @@ class GameControlsComponentTest {
     assertEquals("Pause the game", GameControlsComponent.formatActionLabel("ESC: Pause the game"));
     assertEquals("Shoot", GameControlsComponent.formatActionLabel("SPACE: Shoot"));
     assertEquals("Move spaceship up", GameControlsComponent.formatActionLabel("Move spaceship up"));
+  }
+
+  @Test
+  void shouldGenerateControlsDialogTextWithoutTrailingNewline() {
+    String controlsText = GameControlsComponent.generateControlsDialogText();
+
+    assertFalse(controlsText.endsWith("\n"));
+  }
+
+  @Test
+  void shouldReturnAllControlTextsInDisplayOrder() {
+    String[] controlTexts = GameControlsComponent.getAllControlTexts();
+
+    assertEquals(GameControlsComponent.ControlType.values().length, controlTexts.length);
+    assertEquals(
+        GameControlsComponent.getControlText(GameControlsComponent.ControlType.MOVE_UP),
+        controlTexts[0]);
+    assertEquals(
+        GameControlsComponent.getControlText(GameControlsComponent.ControlType.SHIELD),
+        controlTexts[controlTexts.length - 1]);
   }
 }


### PR DESCRIPTION
## Summary
- centralize music and SFX volume read/update behavior in AudioControlsComponent.VolumeType
- reduce repeated MUSIC/SFX branching in slider and label setup
- add focused tests for audio volume type behavior and controls display output

## Tests
- ..\apache-maven-3.9.11\bin\mvn.cmd "-Dmaven.repo.local=..\.m2\repository" test
- ..\apache-maven-3.9.11\bin\mvn.cmd "-Dmaven.repo.local=..\.m2\repository" spotless:check

Closes #322