### PR TITLE
test: add unit tests for HighScore, LevelManager and KillCountAchievement (#267)

### DIFF
--- a/src/test/java/com/dinosaur/dinosaurexploder/achievements/KillCountAchievementTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/achievements/KillCountAchievementTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.dinosaur.dinosaurexploder.achievements;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class KillCountAchievementTest {
+
+  @Test
+  void newAchievementIsNotCompleted() {
+    KillCountAchievement a = new KillCountAchievement(3, 50);
+    assertFalse(a.isCompleted());
+    assertEquals(50, a.getRewardCoins());
+  }
+
+  @Test
+  void completesAfterEnoughKills() {
+    KillCountAchievement a = new KillCountAchievement(3, 50);
+    a.onDinosaurKilled();
+    a.onDinosaurKilled();
+    assertFalse(a.isCompleted());
+    a.onDinosaurKilled();
+    assertTrue(a.isCompleted());
+  }
+
+  @Test
+  void extraKillsAfterCompletionDontMatter() {
+    KillCountAchievement a = new KillCountAchievement(1, 10);
+    a.onDinosaurKilled();
+    a.onDinosaurKilled();
+    a.onDinosaurKilled();
+    assertTrue(a.isCompleted());
+  }
+}

--- a/src/test/java/com/dinosaur/dinosaurexploder/model/HighScoreTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/model/HighScoreTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.dinosaur.dinosaurexploder.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.dinosaur.dinosaurexploder.constants.GameMode;
+import org.junit.jupiter.api.Test;
+
+class HighScoreTest {
+
+  @Test
+  void newHighScoreStartsAtZero() {
+    HighScore hs = new HighScore();
+    assertEquals(0, hs.getHigh(GameMode.NORMAL.name()));
+    assertEquals(0, hs.getHigh(GameMode.EXPERT.name()));
+  }
+
+  @Test
+  void setHighUpdatesScore() {
+    HighScore hs = new HighScore();
+    hs.setHigh(GameMode.NORMAL.name(), 1500);
+    assertEquals(1500, hs.getHigh(GameMode.NORMAL.name()));
+  }
+
+  @Test
+  void getHighReturnsMaxAcrossModes() {
+    HighScore hs = new HighScore();
+    hs.setHigh(GameMode.NORMAL.name(), 200);
+    hs.setHigh(GameMode.EXPERT.name(), 950);
+    assertEquals(950, hs.getHigh());
+  }
+
+  @Test
+  void unknownModeReturnsZero() {
+    HighScore hs = new HighScore();
+    assertEquals(0, hs.getHigh("not-a-mode"));
+  }
+}

--- a/src/test/java/com/dinosaur/dinosaurexploder/utils/LevelManagerTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/utils/LevelManagerTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.dinosaur.dinosaurexploder.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.dinosaur.dinosaurexploder.constants.GameMode;
+import org.junit.jupiter.api.Test;
+
+class LevelManagerTest {
+
+  @Test
+  void startsAtLevelOne() {
+    LevelManager lm = new LevelManager();
+    assertEquals(1, lm.getCurrentLevel());
+    assertEquals(GameMode.NORMAL, lm.getGameMode());
+  }
+
+  @Test
+  void killingABossAdvancesLevel() {
+    LevelManager lm = new LevelManager();
+    lm.incrementDefeatedBosses();
+    assertTrue(lm.shouldAdvanceLevel());
+  }
+
+  @Test
+  void nextLevelIncreasesEnemyTarget() {
+    LevelManager lm = new LevelManager();
+    int before = lm.getEnemiesToDefeat();
+    lm.nextLevel();
+    assertEquals(2, lm.getCurrentLevel());
+    assertEquals(before + 5, lm.getEnemiesToDefeat());
+  }
+
+  @Test
+  void spawnRateIsClampedAtFloor() {
+    LevelManager lm = new LevelManager();
+    for (int i = 0; i < 100; i++) {
+      lm.nextLevel();
+    }
+    assertTrue(lm.getEnemySpawnRate() >= 0.3);
+  }
+}


### PR DESCRIPTION
### ✅ PR Checklist

> [!TIP]
> Please check the boxes below to confirm you followed the contribution guidelines:

- [x] My PR title follows the format: `type(scope): description (#issue)` (scope and #issue optional)
- [x] I used the correct `type`: feat, fix, refactor, docs, test, chore
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).


### 📝 What does this PR do?

- Adds unit tests for `HighScore` covering default values, setHigh, getHigh across modes, and the unknown mode lookup.
- Adds unit tests for `LevelManager` covering starting state, advancing after a boss defeat, the enemy target growth on `nextLevel`, and the spawn-rate floor.
- Adds unit tests for `KillCountAchievement` covering initial state, completing once the kill threshold is reached, and that extra kills after completion don't change the result.

11 new tests across 3 files. No production code is modified.

### 🔗 Related Issue

> Link to the issue this PR addresses (if any)

- [x] This PR fixes/closes: #267
- [ ] This PR doesn't address a specific issue.

### 📸 Screenshots / Demos (if applicable)

> [!NOTE]
> 🦖 No screenshots or demo provided.

### 💬 Extra Notes (Optional)

This is my first PR to this repo. I picked #267 because it was tagged as a good first issue and adding tests felt like a safe place to start. Happy to add more cases or change anything if needed.

---
