### PR TITLE
feat(website): add changelog page with GitHub Releases API auto-fetch #409

### DIFF
--- a/website/__tests__/changelog.test.tsx
+++ b/website/__tests__/changelog.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import ChangelogPage from "../app/[lang]/changelog/page";
+import ReleaseBody from "../components/changelog/ReleaseBody";
+
+type Release = {
+  id: number;
+  tag_name: string;
+  name: string;
+  body: string;
+  html_url: string;
+  published_at: string;
+};
+
+type FetchLikeResponse = {
+  ok: boolean;
+  json: () => Promise<unknown>;
+};
+
+// Minimal fetch mock type (no `any`)
+type FetchMock = (input: RequestInfo | URL, init?: RequestInit) => Promise<FetchLikeResponse>;
+
+const MOCK_RELEASE: Release = {
+  id: 1,
+  tag_name: "v1.0.0",
+  name: "First Release",
+  body: [
+    "## What's Changed",
+    "* feat: add dino shooting by @alice in https://github.com/jvondermarck/dinosaur-exploder/pull/42",
+    "* fix: game crash on start by @bob in https://github.com/jvondermarck/dinosaur-exploder/pull/43",
+    "",
+    "**Full Changelog**: https://github.com/jvondermarck/dinosaur-exploder/compare/v0.9.0...v1.0.0",
+  ].join("\n"),
+  html_url: "https://github.com/jvondermarck/dinosaur-exploder/releases/tag/v1.0.0",
+  published_at: "2026-01-01T00:00:00Z",
+};
+
+describe("ChangelogPage (server component)", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders changelog heading when API succeeds", async () => {
+    const mockFetch: FetchMock = async () => ({
+      ok: true,
+      json: async () => [MOCK_RELEASE] satisfies Release[],
+    });
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const ui = await ChangelogPage();
+    render(ui);
+
+    expect(screen.getByRole("heading", { name: /changelog/i })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("v1.0.0")).toBeInTheDocument();
+      expect(screen.getByText(/First Release/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when API fails", async () => {
+    const mockFetch: FetchMock = async () => ({
+      ok: false,
+      json: async () => [],
+    });
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const ui = await ChangelogPage();
+    render(ui);
+
+    expect(
+      screen.getByText(/couldn't load releases right now/i)
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'No description provided' for a release with no body", async () => {
+    const emptyRelease: Release = { ...MOCK_RELEASE, body: "" };
+    const mockFetch: FetchMock = async () => ({
+      ok: true,
+      json: async () => [emptyRelease] satisfies Release[],
+    });
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const ui = await ChangelogPage();
+    render(ui);
+
+    expect(screen.getByText(/no description provided/i)).toBeInTheDocument();
+  });
+});
+
+describe("ReleaseBody", () => {
+  it("renders a section header from ## markdown", () => {
+    render(<ReleaseBody body="## What's Changed" />);
+    expect(screen.getByText(/what's changed/i)).toBeInTheDocument();
+  });
+
+  it("renders a feat commit badge", () => {
+    render(<ReleaseBody body="* feat: add dino shooting" />);
+    expect(screen.getByText("feat")).toBeInTheDocument();
+    expect(screen.getByText(/add dino shooting/i)).toBeInTheDocument();
+  });
+
+  it("renders a fix commit badge", () => {
+    render(<ReleaseBody body="* fix: game crash on start" />);
+    expect(screen.getByText("fix")).toBeInTheDocument();
+    expect(screen.getByText(/game crash on start/i)).toBeInTheDocument();
+  });
+
+  it("renders a breaking change badge with !", () => {
+    render(<ReleaseBody body="* feat!: drop Node 16 support" />);
+    expect(screen.getByText("feat!")).toBeInTheDocument();
+  });
+
+  it("renders a scoped commit badge", () => {
+    render(<ReleaseBody body="* fix(ui): fix button alignment" />);
+    expect(screen.getByText("fix(ui)")).toBeInTheDocument();
+  });
+
+  it("renders a PR URL as a clean #N link", () => {
+    render(
+      <ReleaseBody body="* feat: new dino in https://github.com/jvondermarck/dinosaur-exploder/pull/42" />
+    );
+    const prLink = screen.getByRole("link", { name: "#42" });
+    expect(prLink).toBeInTheDocument();
+    expect(prLink).toHaveAttribute(
+      "href",
+      "https://github.com/jvondermarck/dinosaur-exploder/pull/42"
+    );
+  });
+
+  it("renders @mention as a GitHub profile link", () => {
+    render(
+      <ReleaseBody body="* feat: new dino by @alice in https://github.com/jvondermarck/dinosaur-exploder/pull/1" />
+    );
+    const mentionLink = screen.getByRole("link", { name: "@alice" });
+    expect(mentionLink).toBeInTheDocument();
+    expect(mentionLink).toHaveAttribute("href", "https://github.com/alice");
+  });
+
+  it("renders the Full Changelog link shortened to version range", () => {
+    render(
+      <ReleaseBody body="**Full Changelog**: https://github.com/jvondermarck/dinosaur-exploder/compare/v0.9.0...v1.0.0" />
+    );
+    const link = screen.getByRole("link", { name: "v0.9.0...v1.0.0" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/jvondermarck/dinosaur-exploder/compare/v0.9.0...v1.0.0"
+    );
+  });
+
+  it("renders plain text without a badge", () => {
+    render(<ReleaseBody body="This release includes many improvements." />);
+    expect(
+      screen.getByText(/this release includes many improvements/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/website/app/[lang]/changelog/page.tsx
+++ b/website/app/[lang]/changelog/page.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { Metadata } from "next";
+import ReleaseBody from "@/components/changelog/ReleaseBody";
 
 type Release = {
   id: number;
@@ -60,7 +61,7 @@ export default async function ChangelogPage() {
               key={release.id}
               className="bg-white/80 dark:bg-neutral-800/80 rounded-xl border border-green-200 dark:border-green-500/40 p-5 shadow-sm"
             >
-              <div className="flex flex-wrap items-center gap-3 mb-3">
+              <div className="flex flex-wrap items-center gap-3 mb-4">
                 <a
                   href={release.html_url}
                   target="_blank"
@@ -83,9 +84,7 @@ export default async function ChangelogPage() {
                 </span>
               </div>
               {release.body ? (
-                <pre className="font-mono text-sm text-green-950 dark:text-green-100 whitespace-pre-wrap leading-relaxed">
-                  {release.body}
-                </pre>
+                <ReleaseBody body={release.body} />
               ) : (
                 <p className="font-mono text-sm text-green-950 dark:text-green-300 opacity-60 italic">
                   No description provided.

--- a/website/app/[lang]/changelog/page.tsx
+++ b/website/app/[lang]/changelog/page.tsx
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { Metadata } from "next";
+
+type Release = {
+  id: number;
+  tag_name: string;
+  name: string;
+  body: string;
+  html_url: string;
+  published_at: string;
+};
+
+export const metadata: Metadata = {
+  title: "Changelog · Dinosaur Exploder",
+  description: "Release history and version notes for Dinosaur Exploder.",
+};
+
+async function getReleases(): Promise<Release[]> {
+  const res = await fetch(
+    "https://api.github.com/repos/jvondermarck/dinosaur-exploder/releases?per_page=100",
+    {
+      next: { revalidate: 3600 },
+      headers: {
+        "User-Agent": "dinosaur-exploder-website",
+        Accept: "application/vnd.github+json",
+      },
+    }
+  );
+
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export default async function ChangelogPage() {
+  const releases = await getReleases();
+
+  return (
+    <div className="max-w-4xl mx-auto w-full px-4 md:px-8 py-10">
+      <h1 className="font-retro text-3xl md:text-4xl text-green-800 dark:text-green-200 mb-3">
+        Changelog
+      </h1>
+      <p className="font-mono text-green-950 dark:text-green-100 mb-8">
+        All notable releases of Dinosaur Exploder, pulled directly from GitHub.
+      </p>
+
+      {releases.length === 0 ? (
+        <div className="bg-white/80 dark:bg-neutral-800/80 rounded-xl border border-green-200 dark:border-green-500/40 p-5 shadow-sm">
+          <p className="font-mono text-green-950 dark:text-green-100">
+            Couldn&apos;t load releases right now (GitHub API limit or network). Please try again later.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {releases.map((release) => (
+            <div
+              key={release.id}
+              className="bg-white/80 dark:bg-neutral-800/80 rounded-xl border border-green-200 dark:border-green-500/40 p-5 shadow-sm"
+            >
+              <div className="flex flex-wrap items-center gap-3 mb-3">
+                <a
+                  href={release.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-retro text-lg text-green-800 dark:text-green-200 hover:underline"
+                >
+                  {release.tag_name}
+                </a>
+                {release.name && release.name !== release.tag_name && (
+                  <span className="font-mono text-sm text-green-950 dark:text-green-300 opacity-80">
+                    — {release.name}
+                  </span>
+                )}
+                <span className="ml-auto font-mono text-xs text-green-950 dark:text-green-400 opacity-70">
+                  {new Date(release.published_at).toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </span>
+              </div>
+              {release.body ? (
+                <pre className="font-mono text-sm text-green-950 dark:text-green-100 whitespace-pre-wrap leading-relaxed">
+                  {release.body}
+                </pre>
+              ) : (
+                <p className="font-mono text-sm text-green-950 dark:text-green-300 opacity-60 italic">
+                  No description provided.
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/components/NavBar.tsx
+++ b/website/components/NavBar.tsx
@@ -19,6 +19,7 @@ export default function NavBar({ lang, dict }: { lang: string; dict: any }) {
   const navItems = [
     { href: "/how-game-works", label: dict.NavBar.howGameWorks },
     { href: "/credits", label: dict.NavBar.credits },
+    { href: "/changelog", label: "Changelog" },
     { href: "/contact", label: dict.NavBar.contact },
   ];
   const buttonStyle = "px-4 py-2 whitespace-nowrap rounded border font-semibold font-mono transition-all duration-150 text-center flex items-center gap-2 text-sm";

--- a/website/components/changelog/ReleaseBody.tsx
+++ b/website/components/changelog/ReleaseBody.tsx
@@ -23,9 +23,44 @@ const FALLBACK_STYLE = { bg: "bg-neutral-200 dark:bg-neutral-700/60", text: "tex
 
 const COMMIT_TYPE_RE    = /^(feat|fix|chore|docs|style|refactor|test|ci|perf|build|revert)(!?)(\([^)]*\))?\s*:/i;
 const FULL_CHANGELOG_RE = /^\*{0,2}Full Changelog\*{0,2}:\s*(https:\/\/github\.com\/\S+)/i;
+const GITHUB_ASSET_RE   = /^https:\/\/github\.com\/user-attachments\/assets\/[a-zA-Z0-9-]+$/;
+const IMAGE_EXT_RE      = /\.(png|jpe?g|gif|webp|svg|bmp|ico)(\?.*)?$/i;
 
 const isSafeGitHubUrl = (url: string): boolean =>
   /^https:\/\/github\.com\//.test(url);
+
+const isImageUrl = (url: string): boolean => IMAGE_EXT_RE.test(url);
+
+// Renders a GitHub user-attachment asset as a <video> or <img> depending on the URL
+function MediaEmbed({ url }: { url: string }) {
+  if (isImageUrl(url)) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={url}
+        alt="Release media"
+        className="rounded-lg max-w-full my-3 border border-green-200 dark:border-green-700/50 shadow-sm"
+      />
+    );
+  }
+  // GitHub user-attachments without extension are video/mp4
+  return (
+    <video
+      controls
+      className="rounded-lg max-w-full my-3 border border-green-200 dark:border-green-700/50 shadow-sm"
+    >
+      <source src={url} type="video/mp4" />
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-semibold text-green-700 dark:text-green-400 hover:underline"
+      >
+        View video
+      </a>
+    </video>
+  );
+}
 
 // Splits a text fragment into plain strings and React nodes (PR links, @mentions)
 function parseInline(text: string, prefix: string): ReactNode[] {
@@ -179,6 +214,13 @@ export default function ReleaseBody({ body }: { body: string }) {
           </span>
         </li>
       );
+      return;
+    }
+
+    // GitHub user-attachment asset URL → embedded media (video or image)
+    if (GITHUB_ASSET_RE.test(line)) {
+      flushBullets(`pre-media-${i}`);
+      blocks.push(<MediaEmbed key={`media-${i}`} url={line} />);
       return;
     }
 

--- a/website/components/changelog/ReleaseBody.tsx
+++ b/website/components/changelog/ReleaseBody.tsx
@@ -21,21 +21,25 @@ const COMMIT_STYLES: Record<string, { bg: string; text: string }> = {
 };
 const FALLBACK_STYLE = { bg: "bg-neutral-200 dark:bg-neutral-700/60", text: "text-neutral-600 dark:text-neutral-400" };
 
-// g-flag regexes are reset via lastIndex before each use
 const COMMIT_TYPE_RE    = /^(feat|fix|chore|docs|style|refactor|test|ci|perf|build|revert)(!?)(\([^)]*\))?\s*:/i;
-const PR_URL_RE         = /https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/(\d+)/g;
-const MENTION_RE        = /@([a-zA-Z0-9-]+)/g;
 const FULL_CHANGELOG_RE = /^\*{0,2}Full Changelog\*{0,2}:\s*(https:\/\/github\.com\/\S+)/i;
+
+const isSafeGitHubUrl = (url: string): boolean =>
+  /^https:\/\/github\.com\//.test(url);
 
 // Splits a text fragment into plain strings and React nodes (PR links, @mentions)
 function parseInline(text: string, prefix: string): ReactNode[] {
+  // New regex instances per call — no shared mutable lastIndex state
+  const PR_URL_RE  = /https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/(\d+)/g;
+  const MENTION_RE = /@([a-zA-Z0-9-]+)/g;
+
   const hits: Array<{ index: number; end: number; node: ReactNode }> = [];
   let m: RegExpExecArray | null;
 
-  PR_URL_RE.lastIndex = 0;
   while ((m = PR_URL_RE.exec(text)) !== null) {
     const url   = m[0];
     const prNum = m[1];
+    if (!isSafeGitHubUrl(url)) continue;
     hits.push({
       index: m.index,
       end:   m.index + url.length,
@@ -53,16 +57,16 @@ function parseInline(text: string, prefix: string): ReactNode[] {
     });
   }
 
-  MENTION_RE.lastIndex = 0;
   while ((m = MENTION_RE.exec(text)) !== null) {
     const username = m[1];
+    const mentionUrl = `https://github.com/${username}`;
     hits.push({
       index: m.index,
       end:   m.index + m[0].length,
       node: (
         <a
           key={`${prefix}-mention-${m.index}`}
-          href={`https://github.com/${username}`}
+          href={mentionUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="font-semibold text-blue-700 dark:text-blue-400 hover:underline"

--- a/website/components/changelog/ReleaseBody.tsx
+++ b/website/components/changelog/ReleaseBody.tsx
@@ -1,0 +1,192 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+import type { ReactNode } from "react";
+
+// Conventional commit types → Tailwind color classes (listed statically so Tailwind doesn't purge them)
+const COMMIT_STYLES: Record<string, { bg: string; text: string }> = {
+  feat:     { bg: "bg-green-100 dark:bg-green-900/50",     text: "text-green-800 dark:text-green-300" },
+  fix:      { bg: "bg-red-100 dark:bg-red-900/50",         text: "text-red-800 dark:text-red-300" },
+  chore:    { bg: "bg-neutral-200 dark:bg-neutral-700/60", text: "text-neutral-600 dark:text-neutral-400" },
+  docs:     { bg: "bg-blue-100 dark:bg-blue-900/50",       text: "text-blue-800 dark:text-blue-300" },
+  style:    { bg: "bg-purple-100 dark:bg-purple-900/50",   text: "text-purple-800 dark:text-purple-300" },
+  refactor: { bg: "bg-yellow-100 dark:bg-yellow-900/50",   text: "text-yellow-800 dark:text-yellow-300" },
+  test:     { bg: "bg-orange-100 dark:bg-orange-900/50",   text: "text-orange-800 dark:text-orange-300" },
+  ci:       { bg: "bg-indigo-100 dark:bg-indigo-900/50",   text: "text-indigo-800 dark:text-indigo-300" },
+  perf:     { bg: "bg-pink-100 dark:bg-pink-900/50",       text: "text-pink-800 dark:text-pink-300" },
+  build:    { bg: "bg-teal-100 dark:bg-teal-900/50",       text: "text-teal-800 dark:text-teal-300" },
+  revert:   { bg: "bg-rose-100 dark:bg-rose-900/50",       text: "text-rose-800 dark:text-rose-300" },
+};
+const FALLBACK_STYLE = { bg: "bg-neutral-200 dark:bg-neutral-700/60", text: "text-neutral-600 dark:text-neutral-400" };
+
+// g-flag regexes are reset via lastIndex before each use
+const COMMIT_TYPE_RE    = /^(feat|fix|chore|docs|style|refactor|test|ci|perf|build|revert)(!?)(\([^)]*\))?\s*:/i;
+const PR_URL_RE         = /https:\/\/github\.com\/[^\s/]+\/[^\s/]+\/pull\/(\d+)/g;
+const MENTION_RE        = /@([a-zA-Z0-9-]+)/g;
+const FULL_CHANGELOG_RE = /^\*{0,2}Full Changelog\*{0,2}:\s*(https:\/\/github\.com\/\S+)/i;
+
+// Splits a text fragment into plain strings and React nodes (PR links, @mentions)
+function parseInline(text: string, prefix: string): ReactNode[] {
+  const hits: Array<{ index: number; end: number; node: ReactNode }> = [];
+  let m: RegExpExecArray | null;
+
+  PR_URL_RE.lastIndex = 0;
+  while ((m = PR_URL_RE.exec(text)) !== null) {
+    const url   = m[0];
+    const prNum = m[1];
+    hits.push({
+      index: m.index,
+      end:   m.index + url.length,
+      node: (
+        <a
+          key={`${prefix}-pr-${m.index}`}
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold text-green-700 dark:text-green-400 hover:underline"
+        >
+          #{prNum}
+        </a>
+      ),
+    });
+  }
+
+  MENTION_RE.lastIndex = 0;
+  while ((m = MENTION_RE.exec(text)) !== null) {
+    const username = m[1];
+    hits.push({
+      index: m.index,
+      end:   m.index + m[0].length,
+      node: (
+        <a
+          key={`${prefix}-mention-${m.index}`}
+          href={`https://github.com/${username}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold text-blue-700 dark:text-blue-400 hover:underline"
+        >
+          @{username}
+        </a>
+      ),
+    });
+  }
+
+  // Sort by position and drop overlapping matches
+  hits.sort((a, b) => a.index - b.index);
+  const safe: typeof hits = [];
+  let cursor = 0;
+  for (const h of hits) {
+    if (h.index >= cursor) { safe.push(h); cursor = h.end; }
+  }
+
+  const parts: ReactNode[] = [];
+  let last = 0;
+  for (const h of safe) {
+    if (h.index > last) parts.push(text.slice(last, h.index));
+    parts.push(h.node);
+    last = h.end;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}
+
+// Parses a GitHub release body (markdown subset) into styled JSX
+export default function ReleaseBody({ body }: { body: string }) {
+  const lines   = body.split(/\r?\n/);
+  const blocks: ReactNode[] = [];
+  let   bullets: ReactNode[] = [];
+
+  const flushBullets = (key: string) => {
+    if (bullets.length === 0) return;
+    blocks.push(
+      <ul key={`ul-${key}`} className="space-y-1.5 mb-2">
+        {bullets}
+      </ul>
+    );
+    bullets = [];
+  };
+
+  lines.forEach((raw, i) => {
+    const line = raw.trim();
+
+    if (!line) {
+      flushBullets(`gap-${i}`);
+      return;
+    }
+
+    // ## / ### → section header
+    if (/^#{2,3}\s/.test(line)) {
+      flushBullets(`pre-h-${i}`);
+      const text = line.replace(/^#{2,3}\s+/, "");
+      blocks.push(
+        <p key={`h-${i}`} className="font-retro text-xs text-green-700 dark:text-green-400 uppercase tracking-widest mt-4 mb-2 border-b border-green-200 dark:border-green-700/50 pb-1">
+          {text}
+        </p>
+      );
+      return;
+    }
+
+    // Full Changelog footer link → shorten to version range only
+    const clMatch = line.match(FULL_CHANGELOG_RE);
+    if (clMatch) {
+      flushBullets(`pre-cl-${i}`);
+      const url        = clMatch[1];
+      const shortLabel = url.replace(/^https:\/\/github\.com\/[^/]+\/[^/]+\/compare\//, "");
+      blocks.push(
+        <p key={`cl-${i}`} className="mt-3 font-mono text-xs text-green-950 dark:text-green-400 opacity-60">
+          Full Changelog:{" "}
+          <a href={url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+            {shortLabel}
+          </a>
+        </p>
+      );
+      return;
+    }
+
+    // Bullet line (* or -) → commit-type badge + inline parsing
+    const bulletMatch = line.match(/^[*-]\s+(.*)/);
+    if (bulletMatch) {
+      const content   = bulletMatch[1];
+      const typeMatch = content.match(COMMIT_TYPE_RE);
+      let badge: ReactNode = null;
+      let rest  = content;
+
+      if (typeMatch) {
+        const type     = typeMatch[1].toLowerCase();
+        const breaking = typeMatch[2] === "!";
+        const scope    = typeMatch[3] ?? "";
+        const s        = COMMIT_STYLES[type] ?? FALLBACK_STYLE;
+        badge = (
+          <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-mono font-bold flex-shrink-0 ${s.bg} ${s.text}`}>
+            {type}{scope}{breaking ? "!" : ""}
+          </span>
+        );
+        rest = content.slice(typeMatch[0].length).trim();
+      }
+
+      bullets.push(
+        <li key={`li-${i}`} className="flex items-start gap-2">
+          <span className="mt-[7px] w-1.5 h-1.5 rounded-full bg-green-400 dark:bg-green-500 flex-shrink-0" />
+          <span className="flex-1 font-mono text-sm text-green-950 dark:text-green-100 flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            {badge}
+            {parseInline(rest, `${i}`)}
+          </span>
+        </li>
+      );
+      return;
+    }
+
+    // Plain text
+    flushBullets(`pre-p-${i}`);
+    blocks.push(
+      <p key={`p-${i}`} className="font-mono text-sm text-green-950 dark:text-green-100 mb-1">
+        {parseInline(line, `p-${i}`)}
+      </p>
+    );
+  });
+
+  flushBullets("end");
+  return <>{blocks}</>;
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -29,6 +29,7 @@
         "postcss": "^8.5.10",
         "tailwindcss": "^4.1.18",
         "ts-jest": "^29.4.6",
+        "ts-node": "^10.9.2",
         "typescript": "5.9.3"
       }
     },
@@ -578,6 +579,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -2721,6 +2746,34 @@
         }
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3474,6 +3527,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3556,6 +3622,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4296,6 +4369,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4536,6 +4616,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -10364,6 +10454,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -10663,6 +10797,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -11096,6 +11237,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^4.1.18",
     "ts-jest": "^29.4.6",
+    "ts-node": "^10.9.2",
     "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
### 📝 What does this PR do?

| # | Change | Details |
|---|--------|---------|
| ➕ | **New Changelog Page** | Added `/[lang]/changelog` — auto-fetches releases from the GitHub Releases API *(like the Credits page does with contributors)* |
| 🔗 | **Navbar Updated** | Added a navigation link pointing to the new Changelog page |
| 🧪 | **Tests Added** | Unit tests written and passing for the Changelog page |

---

### 🔗 Related Issue

> This pull request was created exclusively to resolve issue **#409** — no other related issues.

- [x] Fixes/closes: **#409**
h release displays its **tag name** and **body description**, following the same pattern as the Credits page.
---

### 📸 Screenshots

![Changelog Page](https://github.com/user-attachments/assets/1fd0f707-9d47-4367-a863-623e0d537fae)

---

### 💬 Extra Notes

> Data is fetched from:
> ```
> GET https://api.github.com/repos/jvondermarck/dinosaur-exploder/releases
> ```
> Each release displays its **tag name** and **body description**, following the same pattern as the Credits page.