### PR TITLE
feat(website): replace sponsor iframe with native card (#466)

### DIFF
--- a/website/__tests__/home.test.tsx
+++ b/website/__tests__/home.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+import { render, screen } from "@testing-library/react";
+import Home from "../app/[lang]/page";
+
+describe("Home", () => {
+  it("renders the English sponsor heading and description", async () => {
+    render(await Home({ params: Promise.resolve({ lang: "en" }) }));
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Sponsor Julien Von Der Marck on GitHub Sponsors",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Passionate open-source dev. I maintain Dinosaur Exploder, a free Java/FXGL shoot ’em up. Welcoming & guiding new contributors every day! 🦖✨"
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders a safe external Sponsor link", async () => {
+    render(await Home({ params: Promise.resolve({ lang: "en" }) }));
+
+    const sponsorLink = screen.getByRole("link", { name: "Sponsor" });
+    expect(sponsorLink).toHaveAttribute(
+      "href",
+      "https://github.com/sponsors/jvondermarck"
+    );
+    expect(sponsorLink).toHaveAttribute("target", "_blank");
+    expect(sponsorLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("does not render an iframe", async () => {
+    const { container } = render(
+      await Home({ params: Promise.resolve({ lang: "en" }) })
+    );
+
+    expect(container.querySelector("iframe")).not.toBeInTheDocument();
+  });
+});

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -4,10 +4,12 @@
  */
 
 import { getDictionary } from "@/getDictionary";
+import SponsorCard from "@/components/SponsorCard";
+import type { Locale } from "@/i18n-config";
 
 export default async function Home({params}: {params: Promise<{lang: string}>}) {
   const {lang} = await params;
-  const dict = await getDictionary(lang as any);
+  const dict = await getDictionary(lang as Locale);
 
   return (
     <div className="flex flex-col">
@@ -79,27 +81,11 @@ export default async function Home({params}: {params: Promise<{lang: string}>}) 
 
       </section>
 
-      {/* Sponsor Section (Card) */}
-      <section className="w-full flex items-center justify-center pb-8">
-        <div className="rounded-xl shadow-lg shadow-black/30 dark:shadow-xl bg-neutral-800/90 dark:bg-white/90 border border-neutral-600 dark:border-green-200/70 p-[5px] max-w-full flex items-center justify-center">
-          <iframe
-            src="https://github.com/sponsors/jvondermarck/card"
-            title="Sponsor jvondermarck"
-            width="600"
-            height="225"
-            style={{
-              minWidth: "280px",
-              border: 0,
-              borderRadius: "0.75rem",
-              background: "transparent",
-              display: "block",
-              verticalAlign: "middle",
-            }}
-            className="max-w-full"
-            allow="payment"
-          />
-        </div>
-      </section>
+      <SponsorCard
+        title={dict.homePage.sponsorDescr.title}
+        description={dict.homePage.sponsorDescr.descr}
+        ctaLabel={dict.homePage.sponsorDescr.heart}
+      />
     </div>
   );
 }

--- a/website/components/SponsorCard.tsx
+++ b/website/components/SponsorCard.tsx
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: 2026 jvondermarck
+ * SPDX-License-Identifier: MIT
+ */
+
+import { FaHeart } from "react-icons/fa";
+
+type SponsorCardProps = {
+  title: string;
+  description: string;
+  ctaLabel: string;
+};
+
+export default function SponsorCard({
+  title,
+  description,
+  ctaLabel,
+}: SponsorCardProps) {
+  return (
+    <section aria-labelledby="sponsor-card-title" className="w-full px-4 pb-10">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 rounded-xl border-2 border-green-700 bg-white/90 p-6 shadow-[4px_4px_0px_0px_theme(colors.green.700)] dark:border-green-500 dark:bg-neutral-900/90 dark:shadow-[4px_4px_0px_0px_theme(colors.green.500)] sm:flex-row sm:items-center sm:justify-between md:px-8">
+        <div className="flex items-start gap-4">
+          <div className="flex-shrink-0 rounded-lg border-2 border-pink-300 bg-pink-100 p-3 text-pink-700 dark:border-pink-500/60 dark:bg-pink-950/60 dark:text-pink-300">
+            <FaHeart aria-hidden="true" size={28} />
+          </div>
+
+          <div>
+            <h2
+              id="sponsor-card-title"
+              className="font-retro text-lg leading-relaxed text-green-800 dark:text-green-200 md:text-xl"
+            >
+              {title}
+            </h2>
+            <p className="mt-3 max-w-2xl font-mono text-sm leading-relaxed text-green-950 dark:text-green-100 md:text-base">
+              {description}
+            </p>
+          </div>
+        </div>
+
+        <a
+          href="https://github.com/sponsors/jvondermarck"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex w-full flex-shrink-0 items-center justify-center gap-2 rounded-full border-2 border-pink-900 bg-pink-700 px-6 py-3 font-retro text-sm text-white shadow-[3px_3px_0px_0px_theme(colors.pink.950)] transition hover:bg-pink-800 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-pink-400 focus-visible:ring-offset-4 focus-visible:ring-offset-white dark:border-pink-300 dark:shadow-[3px_3px_0px_0px_theme(colors.pink.300)] dark:focus-visible:ring-pink-300 dark:focus-visible:ring-offset-neutral-900 sm:w-auto"
+        >
+          <FaHeart aria-hidden="true" />
+          <span>{ctaLabel}</span>
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/website/dictionaries/el.json
+++ b/website/dictionaries/el.json
@@ -13,9 +13,9 @@
         
         "button": "Δείτε το στο Github",
         "sponsorDescr": {
-            "title": "Sponsor Julien Von Der Marck on GitHub Sponsors",
-            "heart": "Sponsor",
-            "descr": "Passionate open-source dev. I maintain Dinosaur Exploder, a free Java/FXGL shoot ’em up. Welcoming & guiding new contributors every day! 🦖✨"
+            "title": "Υποστηρίξτε τον Julien Von Der Marck στο GitHub Sponsors",
+            "heart": "Υποστήριξη",
+            "descr": "Παθιασμένος προγραμματιστής ανοιχτού κώδικα. Συντηρώ το Dinosaur Exploder, ένα δωρεάν shoot ’em up σε Java/FXGL. Καλωσορίζω και καθοδηγώ καθημερινά νέους συνεισφέροντες! 🦖✨"
         }
     },
 

--- a/website/dictionaries/es.json
+++ b/website/dictionaries/es.json
@@ -14,7 +14,7 @@
     "sponsorDescr": {
       "title": "Patrocina a Julien Von Der Marck en GitHub Sponsors",
       "heart": "Patrocinar",
-      "descr": "Desarrollador apasionado de codigo abierto. Mantengo Dinosaur Exploder, un shoot 'em up gratuito de Java/FXGL. Doy la bienvenida y guio a nuevos contribuidores cada dia! 🦖✨"
+      "descr": "Desarrollador apasionado del código abierto. Mantengo Dinosaur Exploder, un shoot ’em up gratuito desarrollado con Java/FXGL. ¡Doy la bienvenida y oriento a nuevos colaboradores todos los días! 🦖✨"
     }
   },
 

--- a/website/dictionaries/fr.json
+++ b/website/dictionaries/fr.json
@@ -12,9 +12,9 @@
         ],
         "button": "Voir sur Github",
         "sponsorDescr": {
-            "title": "Sponsor Julien Von Der Marck on GitHub Sponsors",
-            "heart": "Sponsor",
-            "descr": "Passionate open-source dev. I maintain Dinosaur Exploder, a free Java/FXGL shoot ’em up. Welcoming & guiding new contributors every day! 🦖✨"
+            "title": "Soutenez Julien Von Der Marck sur GitHub Sponsors",
+            "heart": "Soutenir",
+            "descr": "Développeur open source passionné, je maintiens Dinosaur Exploder, un shoot ’em up Java/FXGL gratuit. J’accueille et accompagne chaque jour de nouveaux contributeurs ! 🦖✨"
         }
     },
 

--- a/website/dictionaries/zh_cn.json
+++ b/website/dictionaries/zh_cn.json
@@ -12,9 +12,9 @@
         ],
         "button": "GitHub",
         "sponsorDescr": {
-            "title": "Sponsor Julien Von Der Marck on GitHub Sponsors",
-            "heart": "Sponsor",
-            "descr": "Passionate open-source dev. I maintain Dinosaur Exploder, a free Java/FXGL shoot ’em up. Welcoming & guiding new contributors every day! 🦖✨"
+            "title": "在 GitHub Sponsors 上赞助 Julien Von Der Marck",
+            "heart": "赞助",
+            "descr": "热爱开源开发。我维护着 Dinosaur Exploder，这是一款免费的 Java/FXGL 射击游戏。我每天都会欢迎并指导新的贡献者！🦖✨"
         }
     },
 


### PR DESCRIPTION
### ✅ PR Checklist

> [!TIP]
> Please check the boxes below to confirm you followed the contribution guidelines:

- [x] My PR title follows the format: `type(scope): description (#issue)` (scope and #issue optional)
- [x] I used the correct `type`: feat, fix, refactor, docs, test, chore
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).

### 📝 What does this PR do?

- Replaces the externally rendered GitHub Sponsors iframe with a native responsive card.
- Reuses all existing localized sponsor copy for the heading, description, and CTA.
- Supports light and dark themes without client-side code or new dependencies.
- Adds focused coverage for localized content, destination, external-link safety, and iframe removal.

### 🔗 Related Issue

- [x] This PR fixes/closes: Fixes #466
- [ ] This PR doesn’t address a specific issue.

### 📸 Screenshots / Demos (if applicable)

#### Light mode

<img width="1265" height="1153" alt="sponsor-card-light" src="https://github.com/user-attachments/assets/10e9d6c4-89f6-4d39-8ec7-6e69f2dba7ab" />

#### Dark mode

<img width="1265" height="1153" alt="sponsor-card-dark" src="https://github.com/user-attachments/assets/96eaa156-af31-4711-a61a-a5720d5361e3" />

### 💬 Extra Notes (Optional)

Verification from `website/`:

- `npm ci` — passed
- `npm test -- --runInBand` — passed (5 suites, 24 tests)
- `npx eslint 'app/[lang]/page.tsx' components/SponsorCard.tsx __tests__/home.test.tsx` — passed
- `npm run build` — passed
- `npm run lint` — currently blocked by pre-existing errors in unrelated files on `main`; the changed files pass ESLint.

Browser verification covered the English page in light and dark modes, the stacked 390px layout, the horizontal desktop layout, the sponsor destination, iframe removal, and console errors.

---

❤️ Thanks again for your contribution to Dinosaur Exploder!  
Your efforts help make this project awesome for everyone. 🦖✨
