### PR TITLE
fix: exclude paused time from game-over duration

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameActions.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/controller/core/GameActions.java
@@ -19,6 +19,8 @@ import com.dinosaur.dinosaurexploder.constants.EntityType;
 import com.dinosaur.dinosaurexploder.constants.GameMode;
 import com.dinosaur.dinosaurexploder.model.CollisionHandler;
 import com.dinosaur.dinosaurexploder.model.GameData;
+import com.dinosaur.dinosaurexploder.utils.FXGLGameTimer;
+import com.dinosaur.dinosaurexploder.utils.GameTimer;
 import com.dinosaur.dinosaurexploder.utils.LanguageManager;
 import com.dinosaur.dinosaurexploder.utils.LevelManager;
 import com.dinosaur.dinosaurexploder.utils.TextUtils;
@@ -46,7 +48,7 @@ public class GameActions {
   private final Entity bomb;
   private AllyComponent ally;
   private boolean isAllyUse = false;
-  private final long sessionStartNanos;
+  private final GameTimer sessionTimer;
   private boolean gameOverTriggered = false;
   private static final Logger LOGGER = Logger.getLogger(GameActions.class.getName());
   private double emissionRate;
@@ -74,7 +76,8 @@ public class GameActions {
       this.emissionRate = 0;
     }
 
-    this.sessionStartNanos = System.nanoTime();
+    this.sessionTimer = new FXGLGameTimer();
+    this.sessionTimer.capture();
   }
 
   public void updateLevelDisplay() {
@@ -270,7 +273,7 @@ public class GameActions {
   }
 
   public void gameOver() {
-    new GameOverDialog(languageManager, levelManager, sessionStartNanos).createDialog();
+    new GameOverDialog(languageManager, levelManager, sessionTimer).createDialog();
   }
 
   public AllyComponent getAlly() {

--- a/src/main/java/com/dinosaur/dinosaurexploder/view/GameOverDialog.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/view/GameOverDialog.java
@@ -11,21 +11,22 @@ import static com.almasb.fxgl.dsl.FXGL.getSceneService;
 import com.dinosaur.dinosaurexploder.components.ScoreComponent;
 import com.dinosaur.dinosaurexploder.model.GameData;
 import com.dinosaur.dinosaurexploder.model.GameOverStats;
+import com.dinosaur.dinosaurexploder.utils.GameTimer;
 import com.dinosaur.dinosaurexploder.utils.LanguageManager;
 import com.dinosaur.dinosaurexploder.utils.LevelManager;
-import java.time.Duration;
+import javafx.util.Duration;
 
 public class GameOverDialog {
 
   private final LanguageManager languageManager;
   private final LevelManager levelManager;
-  private final long sessionStartNanos;
+  private final GameTimer sessionTimer;
 
   public GameOverDialog(
-      LanguageManager languageManager, LevelManager levelManager, long sessionStartNanos) {
+      LanguageManager languageManager, LevelManager levelManager, GameTimer sessionTimer) {
     this.languageManager = languageManager;
     this.levelManager = levelManager;
-    this.sessionStartNanos = sessionStartNanos;
+    this.sessionTimer = sessionTimer;
   }
 
   public void createDialog() {
@@ -39,7 +40,10 @@ public class GameOverDialog {
     } catch (Exception ignored) {
     }
 
-    long survivedSeconds = Duration.ofNanos(System.nanoTime() - sessionStartNanos).toSeconds();
+    long survivedSeconds = 0;
+    while (sessionTimer.isElapsed(Duration.seconds(survivedSeconds + 1))) {
+      survivedSeconds++;
+    }
     GameOverStats stats =
         new GameOverStats(
             finalScore, GameData.getHighScore(), levelManager.getCurrentLevel(), survivedSeconds);


### PR DESCRIPTION
Use the existing FXGL game timer for session duration so game-over time advances only with game time rather than wall-clock time.