### PR TITLE
fix(settings): return defaults after repairing malformed settings (#481)

### DIFF
--- a/src/main/java/com/dinosaur/dinosaurexploder/utils/SettingsProvider.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/utils/SettingsProvider.java
@@ -42,9 +42,13 @@ public class SettingsProvider {
       return createSettingsFromProperties(properties);
     } catch (Exception e) {
       File file = new File(SETTINGS_FILE);
-      if (file.delete()) loadSettings();
+      if (file.delete()) {
+        return loadSettings();
+      }
+      Settings defaultSettings = generateDefaultSettings();
+      saveSettings(defaultSettings);
+      return defaultSettings;
     }
-    return null;
   }
 
   public static void saveSettings(Settings settings) {

--- a/src/main/java/com/dinosaur/dinosaurexploder/utils/SettingsProvider.java
+++ b/src/main/java/com/dinosaur/dinosaurexploder/utils/SettingsProvider.java
@@ -26,39 +26,55 @@ public class SettingsProvider {
   private SettingsProvider() {}
 
   public static Settings loadSettings() {
-    Properties properties = new Properties();
-
-    try {
-      FileInputStream in = new FileInputStream(SETTINGS_FILE);
-      properties.load(in);
-      in.close();
-    } catch (Exception ex) {
-      Settings defaultSettings = generateDefaultSettings();
-      saveSettings(defaultSettings);
-      return defaultSettings;
-    }
-
-    try { // handling missing properties from settings.properties file
-      return createSettingsFromProperties(properties);
-    } catch (Exception e) {
-      File file = new File(SETTINGS_FILE);
-      if (file.delete()) {
-        return loadSettings();
+    Properties properties = readSettingsFile();
+    if (properties != null) {
+      try {
+        return createSettingsFromProperties(properties);
+      } catch (Exception e) {
+        logger.log(Level.INFO, "Malformed settings, restoring defaults: {0}", e.getMessage());
+        deleteSettingsFile();
       }
-      Settings defaultSettings = generateDefaultSettings();
-      saveSettings(defaultSettings);
-      return defaultSettings;
     }
+    return saveDefaultSettings();
   }
 
   public static void saveSettings(Settings settings) {
-    Properties properties = createPropertiesFormSettings(settings);
+    Properties properties = createPropertiesFromSettings(settings);
 
     try (FileWriter writer = new FileWriter(SETTINGS_FILE)) {
       properties.store(writer, "store properties");
     } catch (Exception ex) {
       logger.log(Level.INFO, "Error saving settings {0}", ex.getMessage());
     }
+  }
+
+  private static Properties readSettingsFile() {
+    File file = new File(SETTINGS_FILE);
+    if (!file.isFile()) {
+      return null;
+    }
+
+    Properties properties = new Properties();
+    try (FileInputStream in = new FileInputStream(file)) {
+      properties.load(in);
+      return properties;
+    } catch (Exception ex) {
+      logger.log(Level.INFO, "Error reading settings {0}", ex.getMessage());
+      return null;
+    }
+  }
+
+  private static void deleteSettingsFile() {
+    File file = new File(SETTINGS_FILE);
+    if (file.exists() && !file.delete()) {
+      logger.log(Level.INFO, "Could not delete invalid settings file");
+    }
+  }
+
+  private static Settings saveDefaultSettings() {
+    Settings defaults = generateDefaultSettings();
+    saveSettings(defaults);
+    return defaults;
   }
 
   private static Settings createSettingsFromProperties(Properties props) {
@@ -72,7 +88,7 @@ public class SettingsProvider {
     return settings;
   }
 
-  private static Properties createPropertiesFormSettings(Settings settings) {
+  private static Properties createPropertiesFromSettings(Settings settings) {
     Properties properties = new Properties();
     properties.put(SETTING_VOLUME, String.valueOf(settings.getVolume()));
     properties.put(SETTINGS_MUTED, String.valueOf(settings.isMuted()));

--- a/src/test/java/com/dinosaur/dinosaurexploder/utils/SettingsProviderTest.java
+++ b/src/test/java/com/dinosaur/dinosaurexploder/utils/SettingsProviderTest.java
@@ -6,6 +6,10 @@
 package com.dinosaur.dinosaurexploder.utils;
 
 import com.dinosaur.dinosaurexploder.model.Settings;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.util.Properties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -16,5 +20,33 @@ public class SettingsProviderTest {
     Settings settings = SettingsProvider.loadSettings();
     Assertions.assertNotNull(
         settings, "Settings should always be available. At least the default settings");
+  }
+
+  @Test
+  public void loadSettings_returnsDefaultsWhenVolumeIsMalformed() throws Exception {
+    try (FileWriter writer = new FileWriter(SettingsProvider.SETTINGS_FILE)) {
+      writer.write("soundVolume=not-a-number\n");
+      writer.write("soundMuted=false\n");
+      writer.write("soundVolumeSfx=1.0\n");
+      writer.write("soundMutedSfx=false\n");
+      writer.write("selectedLanguage=English\n");
+    }
+
+    Settings settings = SettingsProvider.loadSettings();
+
+    Assertions.assertNotNull(settings);
+    Assertions.assertEquals(1.0, settings.getVolume());
+    Assertions.assertFalse(settings.isMuted());
+    Assertions.assertEquals(1.0, settings.getSfxVolume());
+    Assertions.assertFalse(settings.isSfxMuted());
+    Assertions.assertEquals("English", settings.getLanguage());
+
+    File regenerated = new File(SettingsProvider.SETTINGS_FILE);
+    Assertions.assertTrue(regenerated.exists());
+    Properties properties = new Properties();
+    try (FileInputStream in = new FileInputStream(regenerated)) {
+      properties.load(in);
+    }
+    Assertions.assertEquals("1.0", properties.getProperty(SettingsProvider.SETTING_VOLUME));
   }
 }


### PR DESCRIPTION
### ✅ PR Checklist

- [x] My PR title follows the format: `type(scope): description (#issue)` (scope and #issue optional)
- [x] I used the correct `type`: feat, fix, refactor, docs, test, chore
- [x] I reviewed my code and removed unnecessary debug logs or comments.
- [x] I tested my changes and verified they work as expected.
- [x] I ran the project to confirm it compiles and runs correctly.
- [x] I read the [Code of Conduct](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CODE_OF_CONDUCT.md) and the [Contribution Guidelines](https://github.com/jvondermarck/dinosaur-exploder/blob/main/CONTRIBUTING.md).

### 📝 What does this PR do?

- Return the regenerated default settings from `SettingsProvider.loadSettings()` when a stored value is invalid, instead of falling through to `null`.
- Add a regression test that writes `soundVolume=not-a-number` and checks the first call comes back with defaults and a valid file.

### 🔗 Related Issue

- [x] This PR fixes/closes: #481
- [ ] This PR doesn’t address a specific issue.

### 📸 Screenshots / Demos (if applicable)

> [!NOTE]
> 🦖 No screenshots or demo provided.

### 💬 Extra Notes (Optional)

I ran `mvn -B -Dtest=SettingsProviderTest test` on the malformed file from the issue. It failed on main and passed on this branch.
